### PR TITLE
Remove IE-specific sinon hacks that broke tests

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,6 @@
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
   <script src="/node_modules/sinon/pkg/sinon.js"></script>
-  <script src="/node_modules/sinon/pkg/sinon-ie.js"></script>
   <script src="/node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="/node_modules/video.js/dist/video.js"></script>
   <script src="/dist-test/videojs-contrib-eme.js"></script>

--- a/test/karma/common.js
+++ b/test/karma/common.js
@@ -6,7 +6,6 @@ var DEFAULTS = {
 
   files: [
     'node_modules/sinon/pkg/sinon.js',
-    'node_modules/sinon/pkg/sinon-ie.js',
     'node_modules/video.js/dist/video.js',
     'test/**/*.js'
   ],


### PR DESCRIPTION
We aren't running the automated tests in IE and the location they were being included in was causing other browsers to fail. Remove them until we can find a way to include them that doesn't break cross-platform test running.