### PR TITLE
Close sessions on key expiration and log internal-error key statuses

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -36,6 +36,15 @@ export const hasSession = (sessions, initData) => {
   return false;
 };
 
+export const removeSession = (sessions, initData) => {
+  for (let i = 0; i < sessions.length; i++) {
+    if (sessions[i].initData === initData) {
+      sessions.splice(i, 1);
+      return;
+    }
+  }
+};
+
 export const handleEncryptedEvent = (event, options, sessions) => {
   if (!options || !options.keySystems) {
     // return silently since it may be handled by a different system
@@ -61,7 +70,8 @@ export const handleEncryptedEvent = (event, options, sessions) => {
     video: event.target,
     initDataType: event.initDataType,
     initData: event.initData,
-    options
+    options,
+    removeSession: removeSession.bind(null, sessions)
   });
 };
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -306,6 +306,16 @@ QUnit.test('removeSession removes sessions', function(assert) {
                    [{ initData: initData1 }, { initData: initData3 }],
                    'removed session with initData');
 
+  removeSession(sessions, null);
+  assert.deepEqual(sessions,
+                   [{ initData: initData1 }, { initData: initData3 }],
+                   'does nothing when passed null');
+
+  removeSession(sessions, new Uint8Array([6, 7, 8]));
+  assert.deepEqual(sessions,
+                   [{ initData: initData1 }, { initData: initData3 }],
+                   'does nothing when passed non-matching initData');
+
   removeSession(sessions, new Uint8Array([1, 2, 3]));
   assert.deepEqual(sessions,
                    [{ initData: initData1 }, { initData: initData3 }],

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -11,7 +11,8 @@ import {
   handleEncryptedEvent,
   handleMsNeedKeyEvent,
   handleWebKitNeedKeyEvent,
-  getOptions
+  getOptions,
+  removeSession
 } from '../src/plugin';
 
 const Player = videojs.getComponent('Player');
@@ -286,4 +287,36 @@ QUnit.test('getOptions prioritizes eme options over source options', function(as
     type: 'application/dash+xml',
     extraOption: 'extra-option'
   }, 'updates source options with eme options');
+});
+
+QUnit.test('removeSession removes sessions', function(assert) {
+  const initData1 = new Uint8Array([1, 2, 3]);
+  const initData2 = new Uint8Array([2, 3, 4]);
+  const initData3 = new Uint8Array([3, 4, 5]);
+  const sessions = [{
+    initData: initData1
+  }, {
+    initData: initData2
+  }, {
+    initData: initData3
+  }];
+
+  removeSession(sessions, initData2);
+  assert.deepEqual(sessions,
+                   [{ initData: initData1 }, { initData: initData3 }],
+                   'removed session with initData');
+
+  removeSession(sessions, new Uint8Array([1, 2, 3]));
+  assert.deepEqual(sessions,
+                   [{ initData: initData1 }, { initData: initData3 }],
+                   'did not remove session because initData is not the same reference');
+
+  removeSession(sessions, initData1);
+  assert.deepEqual(sessions,
+                   [{ initData: initData3 }],
+                   'removed session with initData');
+  removeSession(sessions, initData3);
+  assert.deepEqual(sessions, [], 'removed session with initData');
+  removeSession(sessions, initData2);
+  assert.deepEqual(sessions, [], 'does nothing when no sessions');
 });


### PR DESCRIPTION
Still trying to get a test asset where the license expires (preferably configurable), but wanted to put this up for review.