### PR TITLE
Emit event when a license request is attempted

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ without making a request, we can support that, since you can control the methods
 ### Special Events
 
 There are some events that are specific to this plugin.  Once such event is `licenserequestattempted`.
-This event is triggered on the `tech_` on every license request.
+This event is triggered on the `tech_` on the callback of every license request.
 
 In order to listen to this event:
 

--- a/README.md
+++ b/README.md
@@ -314,6 +314,19 @@ flexibility as possible. This means that if your server has a different structur
 a different format for FairPlay content IDs, or you want to test something in the browser
 without making a request, we can support that, since you can control the methods.
 
+### Special Events
+
+There are some events that are specific to this plugin.  Once such event is `licenserequestattempted`.
+This event is triggered on the `tech_` on every license request.
+
+In order to listen to this event:
+
+```
+player.tech_.on('licenserequestattempted', function(event) {
+  // Act on event
+});
+```
+
 ## Getting Started
 
 1. Clone this repository!

--- a/src/eme.js
+++ b/src/eme.js
@@ -178,10 +178,11 @@ const defaultGetLicense = (url) => (emeOptions, keyMessage, callback) => {
   });
 };
 
-const promisifyGetLicense = (getLicenseFn) => {
+const promisifyGetLicense = (getLicenseFn, player) => {
   return (emeOptions, keyMessage) => {
     return new Promise((resolve, reject) => {
       getLicenseFn(emeOptions, keyMessage, (err, license) => {
+        player.trigger('licenseRequestAttempted');
         if (err) {
           reject(err);
         }
@@ -215,7 +216,8 @@ export const standard5July2016 = ({
   initDataType,
   initData,
   options,
-  removeSession
+  removeSession,
+  player
 }) => {
   if (typeof video.mediaKeysObject === 'undefined') {
     // Prevent entering this path again.
@@ -270,7 +272,7 @@ export const standard5July2016 = ({
         certificate,
         createdMediaKeys,
         options,
-        getLicense: promisifyGetLicense(keySystemOptions.getLicense),
+        getLicense: promisifyGetLicense(keySystemOptions.getLicense, player),
         removeSession
       });
     }).catch(

--- a/src/eme.js
+++ b/src/eme.js
@@ -183,7 +183,7 @@ const promisifyGetLicense = (getLicenseFn, player) => {
     return new Promise((resolve, reject) => {
       getLicenseFn(emeOptions, keyMessage, (err, license) => {
         if (player && player.tech_) {
-          player.trigger('licenseRequestAttempted');
+          player.tech_.trigger('licenserequestattempted');
         }
         if (err) {
           reject(err);

--- a/src/eme.js
+++ b/src/eme.js
@@ -182,7 +182,9 @@ const promisifyGetLicense = (getLicenseFn, player) => {
   return (emeOptions, keyMessage) => {
     return new Promise((resolve, reject) => {
       getLicenseFn(emeOptions, keyMessage, (err, license) => {
-        player.tech_.trigger('licenseRequestAttempted');
+        if (player && player.tech_) {
+          player.trigger('licenseRequestAttempted');
+        }
         if (err) {
           reject(err);
         }

--- a/src/eme.js
+++ b/src/eme.js
@@ -182,7 +182,7 @@ const promisifyGetLicense = (getLicenseFn, player) => {
   return (emeOptions, keyMessage) => {
     return new Promise((resolve, reject) => {
       getLicenseFn(emeOptions, keyMessage, (err, license) => {
-        player.trigger('licenseRequestAttempted');
+        player.tech_.trigger('licenseRequestAttempted');
         if (err) {
           reject(err);
         }

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -67,7 +67,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, player})
     keySession.addEventListener('webkitkeymessage', (event) => {
       getLicense(options, contentId, event.message, (err, license) => {
         if (player && player.tech_) {
-          player.tech_.trigger('licenseRequestAttempted');
+          player.tech_.trigger('licenserequestattempted');
         }
         if (err) {
           reject(err);

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -42,7 +42,7 @@ const concatInitDataIdAndCertificate = ({initData, id, cert}) => {
   return new Uint8Array(buffer, 0, buffer.byteLength);
 };
 
-const addKey = ({video, contentId, initData, cert, options, getLicense}) => {
+const addKey = ({video, contentId, initData, cert, options, getLicense, player}) => {
   return new Promise((resolve, reject) => {
     if (!video.webkitKeys) {
       video.webkitSetMediaKeys(new window.WebKitMediaKeys(FAIRPLAY_KEY_SYSTEM));
@@ -66,6 +66,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense}) => {
 
     keySession.addEventListener('webkitkeymessage', (event) => {
       getLicense(options, contentId, event.message, (err, license) => {
+        player.trigger('licenseRequestAttempted');
         if (err) {
           reject(err);
           return;
@@ -127,7 +128,7 @@ const defaultGetLicense = (licenseUri) => {
   };
 };
 
-const fairplay = ({video, initData, options}) => {
+const fairplay = ({video, initData, options, player}) => {
   let fairplayOptions = options.keySystems[FAIRPLAY_KEY_SYSTEM];
   let getCertificate = fairplayOptions.getCertificate ||
     defaultGetCertificate(fairplayOptions.certificateUri);
@@ -151,7 +152,8 @@ const fairplay = ({video, initData, options}) => {
       initData,
       getLicense,
       options,
-      contentId: getContentId(options, initData)
+      contentId: getContentId(options, initData),
+      player
     });
   }).catch(videojs.log.error.bind(videojs.log.error));
 };

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -66,7 +66,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, player})
 
     keySession.addEventListener('webkitkeymessage', (event) => {
       getLicense(options, contentId, event.message, (err, license) => {
-        player.trigger('licenseRequestAttempted');
+        player.tech_.trigger('licenseRequestAttempted');
         if (err) {
           reject(err);
           return;

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -66,7 +66,9 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, player})
 
     keySession.addEventListener('webkitkeymessage', (event) => {
       getLicense(options, contentId, event.message, (err, license) => {
-        player.tech_.trigger('licenseRequestAttempted');
+        if (player && player.tech_) {
+          player.tech_.trigger('licenseRequestAttempted');
+        }
         if (err) {
           reject(err);
           return;

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -4,7 +4,7 @@ import { requestPlayreadyLicense } from './playready';
 
 export const PLAYREADY_KEY_SYSTEM = 'com.microsoft.playready';
 
-export const addKeyToSession = (options, session, event) => {
+export const addKeyToSession = (options, session, event, player) => {
   let playreadyOptions = options.keySystems[PLAYREADY_KEY_SYSTEM];
 
   if (typeof playreadyOptions.getKey === 'function') {
@@ -27,6 +27,7 @@ export const addKeyToSession = (options, session, event) => {
   const url = playreadyOptions.url || event.destinationURL;
 
   requestPlayreadyLicense(url, event.message.buffer, (err, response) => {
+    player.trigger('licenseRequestAttempted');
     if (err) {
       videojs.log.error('Unable to request key from url: ' + url);
       return;
@@ -36,7 +37,7 @@ export const addKeyToSession = (options, session, event) => {
   });
 };
 
-export const createSession = (video, initData, options) => {
+export const createSession = (video, initData, options, player) => {
   const session = video.msKeys.createSession('video/mp4', initData);
 
   if (!session) {
@@ -54,7 +55,7 @@ export const createSession = (video, initData, options) => {
   // eslint-disable-next-line max-len
   // @see [PlayReady License Acquisition]{@link https://msdn.microsoft.com/en-us/library/dn468979.aspx}
   session.addEventListener('mskeymessage', (event) => {
-    addKeyToSession(options, session, event);
+    addKeyToSession(options, session, event, player);
   });
 
   session.addEventListener('mskeyerror', (event) => {
@@ -64,7 +65,7 @@ export const createSession = (video, initData, options) => {
   });
 };
 
-export default ({video, initData, options}) => {
+export default ({video, initData, options, player}) => {
   // Although by the standard examples the presence of video.msKeys is checked first to
   // verify that we aren't trying to create a new session when one already exists, here
   // sessions are managed earlier (on the player.eme object), meaning that at this point
@@ -81,5 +82,5 @@ export default ({video, initData, options}) => {
     return;
   }
 
-  createSession(video, initData, options);
+  createSession(video, initData, options, player);
 };

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -27,7 +27,9 @@ export const addKeyToSession = (options, session, event, player) => {
   const url = playreadyOptions.url || event.destinationURL;
 
   requestPlayreadyLicense(url, event.message.buffer, (err, response) => {
-    player.tech_.trigger('licenseRequestAttempted');
+    if (player && player.tech_) {
+      player.tech_.trigger('licenseRequestAttempted');
+    }
     if (err) {
       videojs.log.error('Unable to request key from url: ' + url);
       return;

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -27,7 +27,7 @@ export const addKeyToSession = (options, session, event, player) => {
   const url = playreadyOptions.url || event.destinationURL;
 
   requestPlayreadyLicense(url, event.message.buffer, (err, response) => {
-    player.trigger('licenseRequestAttempted');
+    player.tech_.trigger('licenseRequestAttempted');
     if (err) {
       videojs.log.error('Unable to request key from url: ' + url);
       return;

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -28,7 +28,7 @@ export const addKeyToSession = (options, session, event, player) => {
 
   requestPlayreadyLicense(url, event.message.buffer, (err, response) => {
     if (player && player.tech_) {
-      player.tech_.trigger('licenseRequestAttempted');
+      player.tech_.trigger('licenserequestattempted');
     }
     if (err) {
       videojs.log.error('Unable to request key from url: ' + url);

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -45,7 +45,7 @@ export const removeSession = (sessions, initData) => {
   }
 };
 
-export const handleEncryptedEvent = (event, options, sessions) => {
+export const handleEncryptedEvent = (event, options, sessions, player) => {
   if (!options || !options.keySystems) {
     // return silently since it may be handled by a different system
     return;
@@ -71,11 +71,12 @@ export const handleEncryptedEvent = (event, options, sessions) => {
     initDataType: event.initDataType,
     initData: event.initData,
     options,
-    removeSession: removeSession.bind(null, sessions)
+    removeSession: removeSession.bind(null, sessions),
+    player
   });
 };
 
-export const handleWebKitNeedKeyEvent = (event, options) => {
+export const handleWebKitNeedKeyEvent = (event, options, player) => {
   if (!options.keySystems || !options.keySystems[FAIRPLAY_KEY_SYSTEM]) {
     // return silently since it may be handled by a different system
     return;
@@ -88,11 +89,12 @@ export const handleWebKitNeedKeyEvent = (event, options) => {
   return fairplay({
     video: event.target,
     initData: event.initData,
-    options
+    options,
+    player
   });
 };
 
-export const handleMsNeedKeyEvent = (event, options, sessions) => {
+export const handleMsNeedKeyEvent = (event, options, sessions, player) => {
   if (!options.keySystems || !options.keySystems[PLAYREADY_KEY_SYSTEM]) {
     // return silently since it may be handled by a different system
     return;
@@ -119,7 +121,8 @@ export const handleMsNeedKeyEvent = (event, options, sessions) => {
   msPrefixed({
     video: event.target,
     initData: event.initData,
-    options
+    options,
+    player
   });
 };
 
@@ -169,7 +172,7 @@ const onPlayerReady = (player) => {
     // https://github.com/videojs/video.js/pull/4780
     // videojs.log('eme', 'Received an \'encrypted\' event');
     setupSessions(player);
-    handleEncryptedEvent(event, getOptions(player), player.eme.sessions);
+    handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player);
   });
   // Support Safari EME with FairPlay
   // (also used in early Chrome or Chrome with EME disabled flag)
@@ -181,7 +184,7 @@ const onPlayerReady = (player) => {
     // TODO it's possible that the video state must be cleared if reusing the same video
     // element between sources
     setupSessions(player);
-    handleWebKitNeedKeyEvent(event, getOptions(player));
+    handleWebKitNeedKeyEvent(event, getOptions(player), player);
   });
 
   // EDGE still fires msneedkey, but should use encrypted instead

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -249,7 +249,7 @@ QUnit.test('accepts a license URL as property', function(assert) {
 });
 
 QUnit.test('5 July 2016 lifecycle', function(assert) {
-  assert.expect(40);
+  assert.expect(45);
 
   let done = assert.async();
   let callbacks = {};
@@ -260,7 +260,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     createSession: 0,
     keySessionGenerateRequest: 0,
     keySessionUpdate: 0,
-    createMediaKeys: 0
+    createMediaKeys: 0,
+    licenseRequestAttempts: 0
   };
 
   navigator.requestMediaKeySystemAccess = (keySystem, options) => {
@@ -291,6 +292,16 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       'org.w3.clearkey': {
         getCertificate,
         getLicense
+      }
+    }
+  };
+
+  const player = {
+    tech_: {
+      trigger: (name) => {
+        if (name === 'licenserequestattempted') {
+          callCounts.licenseRequestAttempts++;
+        }
       }
     }
   };
@@ -326,7 +337,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     video,
     initDataType: '',
     initData: '',
-    options
+    options,
+    player
   });
 
   // Step 1: get key system
@@ -338,6 +350,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
   assert.equal(callCounts.keySessionGenerateRequest, 0, 'key session request not made');
   assert.equal(callCounts.getLicense, 0, 'license not requested');
   assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
+  assert.equal(callCounts.licenseRequestAttempts, 0,
+    'license request event not triggered');
 
   callbacks.requestMediaKeySystemAccess(keySystemAccess);
 
@@ -352,6 +366,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     assert.equal(callCounts.keySessionGenerateRequest, 0, 'key session request not made');
     assert.equal(callCounts.getLicense, 0, 'license not requested');
     assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
+    assert.equal(callCounts.licenseRequestAttempts, 0,
+      'license request event not triggered');
 
     callbacks.getCertificate(null, '');
 
@@ -366,6 +382,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       assert.equal(callCounts.keySessionGenerateRequest, 1, 'key session request made');
       assert.equal(callCounts.getLicense, 0, 'license not requested');
       assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
+      assert.equal(callCounts.licenseRequestAttempts, 0,
+        'license request event not triggered');
 
       keySessionEventListeners.message({});
 
@@ -378,6 +396,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       assert.equal(callCounts.keySessionGenerateRequest, 1, 'key session request made');
       assert.equal(callCounts.getLicense, 1, 'license requested');
       assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
+      assert.equal(callCounts.licenseRequestAttempts, 0,
+        'license request event not triggered');
 
       callbacks.getLicense();
 
@@ -392,6 +412,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
         assert.equal(callCounts.keySessionGenerateRequest, 1, 'key session request made');
         assert.equal(callCounts.getLicense, 1, 'license requested');
         assert.equal(callCounts.keySessionUpdate, 1, 'key session updated');
+        assert.equal(callCounts.licenseRequestAttempts, 1,
+          'license request event triggered');
 
         done();
       });

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -351,7 +351,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
   assert.equal(callCounts.getLicense, 0, 'license not requested');
   assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
   assert.equal(callCounts.licenseRequestAttempts, 0,
-    'license request event not triggered');
+    'license request event not triggered (since no callback yet)');
 
   callbacks.requestMediaKeySystemAccess(keySystemAccess);
 
@@ -367,7 +367,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     assert.equal(callCounts.getLicense, 0, 'license not requested');
     assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
     assert.equal(callCounts.licenseRequestAttempts, 0,
-      'license request event not triggered');
+      'license request event not triggered (since no callback yet)');
 
     callbacks.getCertificate(null, '');
 
@@ -383,7 +383,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       assert.equal(callCounts.getLicense, 0, 'license not requested');
       assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
       assert.equal(callCounts.licenseRequestAttempts, 0,
-        'license request event not triggered');
+        'license request event not triggered (since no callback yet)');
 
       keySessionEventListeners.message({});
 
@@ -397,7 +397,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       assert.equal(callCounts.getLicense, 1, 'license requested');
       assert.equal(callCounts.keySessionUpdate, 0, 'key session not updated');
       assert.equal(callCounts.licenseRequestAttempts, 0,
-        'license request event not triggered');
+        'license request event not triggered (since no callback yet)');
 
       callbacks.getLicense();
 

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -92,7 +92,7 @@ QUnit.test('lifecycle', function(assert) {
   assert.equal(callCounts.getLicense, 0, 'getLicense has not been called');
   assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
   assert.equal(callCounts.licenseRequestAttempts, 0,
-    'license request event not triggered');
+    'license request event not triggered (since no callback yet)');
 
   callbacks.getCertificate(null, new Uint16Array([4, 5, 6, 7]).buffer);
 
@@ -103,7 +103,7 @@ QUnit.test('lifecycle', function(assert) {
     assert.equal(callCounts.getLicense, 0, 'getLicense has not been called');
     assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
     assert.equal(callCounts.licenseRequestAttempts, 0,
-      'license request event not triggered');
+      'license request event not triggered (since no callback yet)');
 
     assert.ok(keySessionEventListeners.webkitkeymessage,
               'added an event listener for webkitkeymessage');
@@ -120,7 +120,7 @@ QUnit.test('lifecycle', function(assert) {
     assert.equal(callCounts.getLicense, 1, 'getLicense has been called');
     assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
     assert.equal(callCounts.licenseRequestAttempts, 0,
-      'license request event not triggered');
+      'license request event not triggered (since no callback yet)');
 
     callbacks.getLicense(null, []);
 

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -5,7 +5,7 @@ import fairplay from '../src/fairplay';
 QUnit.module('videojs-contrib-eme fairplay');
 
 QUnit.test('lifecycle', function(assert) {
-  assert.expect(19);
+  assert.expect(23);
 
   let done = assert.async();
   let initData = new Uint8Array([1, 2, 3, 4]).buffer;
@@ -14,7 +14,8 @@ QUnit.test('lifecycle', function(assert) {
     getCertificate: 0,
     getLicense: 0,
     updateKeySession: 0,
-    createSession: 0
+    createSession: 0,
+    licenseRequestAttempts: 0
   };
 
   let getCertificate = (emeOptions, callback) => {
@@ -33,6 +34,16 @@ QUnit.test('lifecycle', function(assert) {
         getLicense,
         // not needed due to mocking
         getContentId: () => 'some content id'
+      }
+    }
+  };
+
+  const player = {
+    tech_: {
+      trigger: (name) => {
+        if (name === 'licenserequestattempted') {
+          callCounts.licenseRequestAttempts++;
+        }
       }
     }
   };
@@ -70,7 +81,7 @@ QUnit.test('lifecycle', function(assert) {
     }
   };
 
-  fairplay({ video, initData, options })
+  fairplay({ video, initData, options, player })
     .then(() => {
       done();
     });
@@ -80,6 +91,8 @@ QUnit.test('lifecycle', function(assert) {
   assert.equal(callCounts.createSession, 0, 'a key session has not been created');
   assert.equal(callCounts.getLicense, 0, 'getLicense has not been called');
   assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
+  assert.equal(callCounts.licenseRequestAttempts, 0,
+    'license request event not triggered');
 
   callbacks.getCertificate(null, new Uint16Array([4, 5, 6, 7]).buffer);
 
@@ -89,6 +102,8 @@ QUnit.test('lifecycle', function(assert) {
     assert.equal(callCounts.createSession, 1, 'a key session has been created');
     assert.equal(callCounts.getLicense, 0, 'getLicense has not been called');
     assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
+    assert.equal(callCounts.licenseRequestAttempts, 0,
+      'license request event not triggered');
 
     assert.ok(keySessionEventListeners.webkitkeymessage,
               'added an event listener for webkitkeymessage');
@@ -104,6 +119,8 @@ QUnit.test('lifecycle', function(assert) {
     assert.equal(callCounts.createSession, 1, 'a key session has been created');
     assert.equal(callCounts.getLicense, 1, 'getLicense has been called');
     assert.equal(callCounts.updateKeySession, 0, 'updateKeySession has not been called');
+    assert.equal(callCounts.licenseRequestAttempts, 0,
+      'license request event not triggered');
 
     callbacks.getLicense(null, []);
 
@@ -112,6 +129,8 @@ QUnit.test('lifecycle', function(assert) {
     assert.equal(callCounts.createSession, 1, 'a key session has been created');
     assert.equal(callCounts.getLicense, 1, 'getLicense has been called');
     assert.equal(callCounts.updateKeySession, 1, 'updateKeySession has been called');
+    assert.equal(callCounts.licenseRequestAttempts, 1,
+      'license request event triggered');
 
     keySessionEventListeners.webkitkeyadded();
   };

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -405,7 +405,8 @@ QUnit.test('makes request with provided url on key message', function(assert) {
   assert.equal(xhrCalls[0].config.responseType,
                'arraybuffer',
                'responseType is an arraybuffer');
-  assert.equal(callCounts.licenseRequestAttempts, 0, 'license request event not triggered');
+  assert.equal(callCounts.licenseRequestAttempts, 0,
+    'license request event not triggered (since no callback yet)');
 
   const origErrorLog = videojs.log.error;
   let errorMessage;

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -349,6 +349,9 @@ QUnit.test('makes request with provided url string on key message', function(ass
 QUnit.test('makes request with provided url on key message', function(assert) {
   const origXhr = videojs.xhr;
   const xhrCalls = [];
+  const callCounts = {
+    licenseRequestAttempts: 0
+  };
 
   videojs.xhr = (config, callback) => xhrCalls.push({config, callback});
 
@@ -359,6 +362,15 @@ QUnit.test('makes request with provided url on key message', function(assert) {
       keySystems: {
         'com.microsoft.playready': {
           url: 'provided-url'
+        }
+      }
+    },
+    player: {
+      tech_: {
+        trigger: (event) => {
+          if (event === 'licenserequestattempted') {
+            callCounts.licenseRequestAttempts++;
+          }
         }
       }
     }
@@ -393,6 +405,7 @@ QUnit.test('makes request with provided url on key message', function(assert) {
   assert.equal(xhrCalls[0].config.responseType,
                'arraybuffer',
                'responseType is an arraybuffer');
+  assert.equal(callCounts.licenseRequestAttempts, 0, 'license request event not triggered');
 
   const origErrorLog = videojs.log.error;
   let errorMessage;
@@ -407,6 +420,7 @@ QUnit.test('makes request with provided url on key message', function(assert) {
 
   xhrCalls[0].callback('an error', response);
 
+  assert.equal(callCounts.licenseRequestAttempts, 1, 'license request event triggered');
   assert.equal(errorMessage,
                'Unable to request key from url: provided-url',
                'logs error when callback has an error');
@@ -414,6 +428,8 @@ QUnit.test('makes request with provided url on key message', function(assert) {
 
   xhrCalls[0].callback(null, response);
 
+  assert.equal(callCounts.licenseRequestAttempts, 2,
+    'second license request event triggered');
   assert.equal(this.session.keys.length, 1, 'key added to session');
   assert.deepEqual(this.session.keys[0],
                    new Uint8Array(response.body),


### PR DESCRIPTION
I'm still working through this, this PR is more to clarify on whether the path is the best way to move.

My primary question here is who should trigger the event, currently it is the `player`, but it could be `player.eme` as well.  Input here would be appreciated.