### PR TITLE
Trigger key status changes on player tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Maintenance Status: Experimental
   - [Plugin Options](#plugin-options)
   - [emeOptions](#emeoptions)
   - [Passing methods seems complicated](#passing-methods-seems-complicated)
+  - [Special Events](#special-events)
 - [Getting Started](#getting-started)
   - [Running Tests](#running-tests)
   - [Tag and Release](#tag-and-release)

--- a/README.md
+++ b/README.md
@@ -327,6 +327,24 @@ player.tech_.on('licenserequestattempted', function(event) {
 });
 ```
 
+Additionally, when the status of a key changes, an event of type `keystatuschange` will
+be triggered on the `tech_`. This helps you handle feedback to the user for situations
+like trying to play DRM-protected media on restricted devices.
+
+Just like the above, you can listen to the event like so:
+
+```
+player.tech_.on('keystatuschange', function(event) {
+  // Event data:
+  // keyId
+  // status: usable, output-restricted, etc
+  // target: the MediaKeySession object that caused this event
+});
+```
+
+It is triggered directly from the underlying `keystatuseschange` event, so the statuses
+should correspond to [those listed in the spec](https://www.w3.org/TR/encrypted-media/#dom-mediakeystatus).
+
 ## Getting Started
 
 1. Clone this repository!

--- a/src/eme.js
+++ b/src/eme.js
@@ -41,7 +41,8 @@ export const makeNewRequest = ({
   initData,
   options,
   getLicense,
-  removeSession
+  removeSession,
+  player
 }) => {
   let keySession = mediaKeys.createSession();
 
@@ -58,6 +59,15 @@ export const makeNewRequest = ({
 
     // based on https://www.w3.org/TR/encrypted-media/#example-using-all-events
     keySession.keyStatuses.forEach((status, keyId) => {
+      // Trigger an event so that other things can take action if appropriate.
+      // For instance, the `output-restricted` status should result in an
+      // error being thrown.
+      player.tech_.trigger({
+        keyId,
+        status,
+        target: keySession,
+        type: 'keystatuschange'
+      });
       switch (status) {
       case 'expired':
         // If one key is expired in a session, all keys are expired. From
@@ -100,7 +110,8 @@ const addSession = ({
   initData,
   options,
   getLicense,
-  removeSession
+  removeSession,
+  player
 }) => {
   if (video.mediaKeysObject) {
     makeNewRequest({
@@ -109,7 +120,8 @@ const addSession = ({
       initData,
       options,
       getLicense,
-      removeSession
+      removeSession,
+      player
     });
   } else {
     video.pendingSessionData.push({initDataType, initData});
@@ -122,7 +134,8 @@ const setMediaKeys = ({
   createdMediaKeys,
   options,
   getLicense,
-  removeSession
+  removeSession,
+  player
 }) => {
   video.mediaKeysObject = createdMediaKeys;
 
@@ -139,7 +152,8 @@ const setMediaKeys = ({
       initData: data.initData,
       options,
       getLicense,
-      removeSession
+      removeSession,
+      player
     });
   }
 
@@ -274,7 +288,8 @@ export const standard5July2016 = ({
         createdMediaKeys,
         options,
         getLicense: promisifyGetLicense(keySystemOptions.getLicense, player),
-        removeSession
+        removeSession,
+        player
       });
     }).catch(
       videojs.log.error.bind(videojs.log.error,
@@ -293,7 +308,8 @@ export const standard5July2016 = ({
         promisifyGetLicense(standardizeKeySystemOptions(
           video.keySystem,
           options.keySystems[video.keySystem]).getLicense, player) : null,
-      removeSession
+      removeSession,
+      player
     });
   });
 };

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -42,7 +42,7 @@ const concatInitDataIdAndCertificate = ({initData, id, cert}) => {
   return new Uint8Array(buffer, 0, buffer.byteLength);
 };
 
-const addKey = ({video, contentId, initData, cert, options, getLicense, player}) => {
+const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus}) => {
   return new Promise((resolve, reject) => {
     if (!video.webkitKeys) {
       video.webkitSetMediaKeys(new window.WebKitMediaKeys(FAIRPLAY_KEY_SYSTEM));
@@ -66,8 +66,8 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, player})
 
     keySession.addEventListener('webkitkeymessage', (event) => {
       getLicense(options, contentId, event.message, (err, license) => {
-        if (player && player.tech_) {
-          player.tech_.trigger('licenserequestattempted');
+        if (eventBus) {
+          eventBus.trigger('licenserequestattempted');
         }
         if (err) {
           reject(err);
@@ -130,7 +130,7 @@ const defaultGetLicense = (licenseUri) => {
   };
 };
 
-const fairplay = ({video, initData, options, player}) => {
+const fairplay = ({video, initData, options, eventBus}) => {
   let fairplayOptions = options.keySystems[FAIRPLAY_KEY_SYSTEM];
   let getCertificate = fairplayOptions.getCertificate ||
     defaultGetCertificate(fairplayOptions.certificateUri);
@@ -155,7 +155,7 @@ const fairplay = ({video, initData, options, player}) => {
       getLicense,
       options,
       contentId: getContentId(options, initData),
-      player
+      eventBus
     });
   }).catch(videojs.log.error.bind(videojs.log.error));
 };

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -4,7 +4,7 @@ import { requestPlayreadyLicense } from './playready';
 
 export const PLAYREADY_KEY_SYSTEM = 'com.microsoft.playready';
 
-export const addKeyToSession = (options, session, event, player) => {
+export const addKeyToSession = (options, session, event, eventBus) => {
   let playreadyOptions = options.keySystems[PLAYREADY_KEY_SYSTEM];
 
   if (typeof playreadyOptions.getKey === 'function') {
@@ -27,8 +27,8 @@ export const addKeyToSession = (options, session, event, player) => {
   const url = playreadyOptions.url || event.destinationURL;
 
   requestPlayreadyLicense(url, event.message.buffer, (err, response) => {
-    if (player && player.tech_) {
-      player.tech_.trigger('licenserequestattempted');
+    if (eventBus) {
+      eventBus.trigger('licenserequestattempted');
     }
     if (err) {
       videojs.log.error('Unable to request key from url: ' + url);
@@ -39,7 +39,7 @@ export const addKeyToSession = (options, session, event, player) => {
   });
 };
 
-export const createSession = (video, initData, options, player) => {
+export const createSession = (video, initData, options, eventBus) => {
   const session = video.msKeys.createSession('video/mp4', initData);
 
   if (!session) {
@@ -57,7 +57,7 @@ export const createSession = (video, initData, options, player) => {
   // eslint-disable-next-line max-len
   // @see [PlayReady License Acquisition]{@link https://msdn.microsoft.com/en-us/library/dn468979.aspx}
   session.addEventListener('mskeymessage', (event) => {
-    addKeyToSession(options, session, event, player);
+    addKeyToSession(options, session, event, eventBus);
   });
 
   session.addEventListener('mskeyerror', (event) => {
@@ -67,7 +67,7 @@ export const createSession = (video, initData, options, player) => {
   });
 };
 
-export default ({video, initData, options, player}) => {
+export default ({video, initData, options, eventBus}) => {
   // Although by the standard examples the presence of video.msKeys is checked first to
   // verify that we aren't trying to create a new session when one already exists, here
   // sessions are managed earlier (on the player.eme object), meaning that at this point
@@ -84,5 +84,5 @@ export default ({video, initData, options, player}) => {
     return;
   }
 
-  createSession(video, initData, options, player);
+  createSession(video, initData, options, eventBus);
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -45,7 +45,7 @@ export const removeSession = (sessions, initData) => {
   }
 };
 
-export const handleEncryptedEvent = (event, options, sessions, player) => {
+export const handleEncryptedEvent = (event, options, sessions, eventBus) => {
   if (!options || !options.keySystems) {
     // return silently since it may be handled by a different system
     return Promise.resolve();
@@ -81,12 +81,12 @@ export const handleEncryptedEvent = (event, options, sessions, player) => {
       initData,
       options,
       removeSession: removeSession.bind(null, sessions),
-      player
+      eventBus
     });
   });
 };
 
-export const handleWebKitNeedKeyEvent = (event, options, player) => {
+export const handleWebKitNeedKeyEvent = (event, options, eventBus) => {
   if (!options.keySystems || !options.keySystems[FAIRPLAY_KEY_SYSTEM]) {
     // return silently since it may be handled by a different system
     return;
@@ -100,11 +100,11 @@ export const handleWebKitNeedKeyEvent = (event, options, player) => {
     video: event.target,
     initData: event.initData,
     options,
-    player
+    eventBus
   });
 };
 
-export const handleMsNeedKeyEvent = (event, options, sessions, player) => {
+export const handleMsNeedKeyEvent = (event, options, sessions, eventBus) => {
   if (!options.keySystems || !options.keySystems[PLAYREADY_KEY_SYSTEM]) {
     // return silently since it may be handled by a different system
     return;
@@ -132,7 +132,7 @@ export const handleMsNeedKeyEvent = (event, options, sessions, player) => {
     video: event.target,
     initData: event.initData,
     options,
-    player
+    eventBus
   });
 };
 
@@ -182,7 +182,7 @@ const onPlayerReady = (player) => {
     // https://github.com/videojs/video.js/pull/4780
     // videojs.log('eme', 'Received an \'encrypted\' event');
     setupSessions(player);
-    handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player);
+    handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player.tech_);
   });
   // Support Safari EME with FairPlay
   // (also used in early Chrome or Chrome with EME disabled flag)
@@ -194,7 +194,7 @@ const onPlayerReady = (player) => {
     // TODO it's possible that the video state must be cleared if reusing the same video
     // element between sources
     setupSessions(player);
-    handleWebKitNeedKeyEvent(event, getOptions(player), player);
+    handleWebKitNeedKeyEvent(event, getOptions(player), player.tech_);
   });
 
   // EDGE still fires msneedkey, but should use encrypted instead
@@ -208,7 +208,7 @@ const onPlayerReady = (player) => {
     // https://github.com/videojs/video.js/pull/4780
     // videojs.log('eme', 'Received an \'msneedkey\' event');
     setupSessions(player);
-    handleMsNeedKeyEvent(event, getOptions(player), player.eme.sessions);
+    handleMsNeedKeyEvent(event, getOptions(player), player.eme.sessions, player.tech_);
   });
 };
 

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -30,19 +30,17 @@ const getMockSession = () => {
 
 QUnit.module('videojs-contrib-eme eme');
 
-QUnit.test('keystatuseschange triggers keystatuschange on player tech for each key', function(assert) {
+QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key', function(assert) {
   let callCount = {total: 0, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}};
   const initData = new Uint8Array([1, 2, 3]);
   const mockSession = getMockSession();
-  const player = {
-    tech_: {
-      trigger: (event) => {
-        if (callCount[event.keyId][event.status] === undefined) {
-          callCount[event.keyId][event.status] = 0;
-        }
-        callCount[event.keyId][event.status]++;
-        callCount.total++;
+  const eventBus = {
+    trigger: (event) => {
+      if (!callCount[event.keyId][event.status]) {
+        callCount[event.keyId][event.status] = 0;
       }
+      callCount[event.keyId][event.status]++;
+      callCount.total++;
     }
   };
 
@@ -55,7 +53,7 @@ QUnit.test('keystatuseschange triggers keystatuschange on player tech for each k
     options: {},
     getLicense() {},
     removeSession() {},
-    player
+    eventBus
   });
 
   assert.equal(mockSession.listeners.length, 2, 'added listeners');
@@ -133,10 +131,8 @@ QUnit.test('keystatuseschange with expired key closes session', function(assert)
   const removeSession = (initData) => removeSessionCalls.push(initData);
   const initData = new Uint8Array([1, 2, 3]);
   const mockSession = getMockSession();
-  const player = {
-    tech_: {
-      trigger: (name) => {}
-    }
+  const eventBus = {
+    trigger: (name) => {}
   };
 
   makeNewRequest({
@@ -148,7 +144,7 @@ QUnit.test('keystatuseschange with expired key closes session', function(assert)
     options: {},
     getLicense() {},
     removeSession,
-    player
+    eventBus
   });
 
   assert.equal(mockSession.listeners.length, 2, 'added listeners');
@@ -185,10 +181,8 @@ QUnit.test('keystatuseschange with internal-error logs a warning', function(asse
   const initData = new Uint8Array([1, 2, 3]);
   const mockSession = getMockSession();
   const warnCalls = [];
-  const player = {
-    tech_: {
-      trigger: (name) => {}
-    }
+  const eventBus = {
+    trigger: (name) => {}
   };
 
   videojs.log.warn = (...args) => warnCalls.push(args);
@@ -202,7 +196,7 @@ QUnit.test('keystatuseschange with internal-error logs a warning', function(asse
     options: {},
     getLicense() {},
     removeSession() {},
-    player
+    eventBus
   });
 
   assert.equal(mockSession.listeners.length, 2, 'added listeners');
@@ -408,12 +402,10 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     }
   };
 
-  const player = {
-    tech_: {
-      trigger: (name) => {
-        if (name === 'licenserequestattempted') {
-          callCounts.licenseRequestAttempts++;
-        }
+  const eventBus = {
+    trigger: (name) => {
+      if (name === 'licenserequestattempted') {
+        callCounts.licenseRequestAttempts++;
       }
     }
   };
@@ -450,7 +442,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     initDataType: '',
     initData: '',
     options,
-    player
+    eventBus
   });
 
   // Step 1: get key system

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -38,12 +38,10 @@ QUnit.test('lifecycle', function(assert) {
     }
   };
 
-  const player = {
-    tech_: {
-      trigger: (name) => {
-        if (name === 'licenserequestattempted') {
-          callCounts.licenseRequestAttempts++;
-        }
+  const eventBus = {
+    trigger: (name) => {
+      if (name === 'licenserequestattempted') {
+        callCounts.licenseRequestAttempts++;
       }
     }
   };
@@ -81,7 +79,7 @@ QUnit.test('lifecycle', function(assert) {
     }
   };
 
-  fairplay({ video, initData, options, player })
+  fairplay({ video, initData, options, eventBus })
     .then(() => {
       done();
     });

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -365,12 +365,10 @@ QUnit.test('makes request with provided url on key message', function(assert) {
         }
       }
     },
-    player: {
-      tech_: {
-        trigger: (event) => {
-          if (event === 'licenserequestattempted') {
-            callCounts.licenseRequestAttempts++;
-          }
+    eventBus: {
+      trigger: (event) => {
+        if (event === 'licenserequestattempted') {
+          callCounts.licenseRequestAttempts++;
         }
       }
     }


### PR DESCRIPTION
Some DRM configurations will block or downscale output when trying to play. With this change, such restrictions can be handled on-the-fly by the player and take appropriate action.

I was debating triggering only events for `output-restricted` and `output-downscaled` statuses, but I think it makes more sense to just keep it generic. That way any future extensions won't need code additions.

Also added a missing TOC entry.