### PR TITLE
Promisify all the things and error on player

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,10 +355,11 @@ var emeCallback = function(error) {
 player.eme.initializeMediaKeys(emeOptions, emeCallback, suppressErrorsIfPossible);
 ```
 
-With `suppressErrorsIfPossible` set to `false` (the default), the error handler
-will be invoked after the callback finishes, and `error` called on the player.
-When set to `true`, the error handler will not be invoked, with the exception
-of `mskeyerror` errors in IE11.
+When `suppressErrorsIfPossible` is set to `false` (the default) and an error
+occurs, the error handler will be invoked after the callback finishes, and
+`error` called on the player. When set to `true` and an error occurs, the
+error handler will not be invoked, with the exception of `mskeyerror` errors
+in IE11 since they cannot be suppressed asynchronously.
 
 ### Passing methods seems complicated
 

--- a/README.md
+++ b/README.md
@@ -344,17 +344,21 @@ var emeOptions = {
   }
 };
 
-player.eme.initializeMediaKeys(emeOptions, function(error) {
+var emeCallback = function(error) {
   if (error) {
     // do something with error
   }
 
   // do something else
-});
+};
+
+player.eme.initializeMediaKeys(emeOptions, emeCallback, suppressErrorsIfPossible);
 ```
 
-Note that if the callback returns anything other than `false`, an error will be fired on
-the player automatically if DRM setup fails.
+With `suppressErrorsIfPossible` set to `false` (the default), the error handler
+will be invoked after the callback finishes, and `error` called on the player.
+When set to `true`, the error handler will not be invoked, with the exception
+of `mskeyerror` errors in IE11.
 
 ### Passing methods seems complicated
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ player.src({
 ### initializeMediaKeys
 Type: `function`
 
-`player.eme.initializeMediaKeys()` sets up MediaKeys immediately on demand. This is useful for setting up the video element for DRM before loading any content. Otherwise the video element is set up for DRM on `encrypted` events. This is not supported in Safari.
+`player.eme.initializeMediaKeys()` sets up MediaKeys immediately on demand. This is useful
+for setting up the video element for DRM before loading any content. Otherwise the video
+element is set up for DRM on `encrypted` events. This is not supported in Safari.
 
 ```javascript
 // additional plugin options
@@ -350,6 +352,9 @@ player.eme.initializeMediaKeys(emeOptions, function(error) {
   // do something else
 });
 ```
+
+Note that if the callback returns anything other than `false`, an error will be fired on
+the player automatically if DRM setup fails.
 
 ### Passing methods seems complicated
 

--- a/src/eme.js
+++ b/src/eme.js
@@ -210,6 +210,7 @@ const promisifyGetLicense = (getLicenseFn, eventBus) => {
         }
         if (err) {
           reject(err);
+          return;
         }
 
         resolve(license);

--- a/src/eme.js
+++ b/src/eme.js
@@ -52,7 +52,7 @@ export const makeNewRequest = ({
     keySession.addEventListener('message', (event) => {
       getLicense(options, event.message)
         .then((license) => {
-          return keySession.update(license);
+          resolve(keySession.update(license));
         })
         .catch((err) => {
           reject(err);

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -157,7 +157,7 @@ const fairplay = ({video, initData, options, eventBus}) => {
       contentId: getContentId(options, initData),
       eventBus
     });
-  }).catch(videojs.log.error.bind(videojs.log.error));
+  });
 };
 
 export default fairplay;

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -66,7 +66,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
         'video/mp4',
         concatInitDataIdAndCertificate({id: contentId, initData, cert}));
     } catch (error) {
-      reject('Could not create key session: invalid mimeType or initData');
+      reject('Could not create key session');
       return;
     }
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -55,6 +55,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
         video.webkitSetMediaKeys(new window.WebKitMediaKeys(FAIRPLAY_KEY_SYSTEM));
       } catch (error) {
         reject('Could not create MediaKeys');
+        return;
       }
     }
 
@@ -66,6 +67,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
         concatInitDataIdAndCertificate({id: contentId, initData, cert}));
     } catch (error) {
       reject('Could not create key session: invalid mimeType or initData');
+      return;
     }
 
     keySession.contentId = contentId;
@@ -77,6 +79,7 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
         }
         if (err) {
           reject(err);
+          return;
         }
 
         keySession.update(new Uint8Array(license));

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -1,5 +1,8 @@
 /**
- * @see https://www.w3.org/TR/2014/WD-encrypted-media-20140218
+ * The W3C Working Draft of 22 October 2013 seems to be the best match for
+ * the ms-prefixed API. However, it should only be used as a guide; it is
+ * doubtful the spec is 100% implemented as described.
+ * @see https://www.w3.org/TR/2013/WD-encrypted-media-20131022
  */
 import videojs from 'video.js';
 import window from 'global/window';

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -1,3 +1,6 @@
+/**
+ * @see https://www.w3.org/TR/2014/WD-encrypted-media-20140218
+ */
 import window from 'global/window';
 import { requestPlayreadyLicense } from './playready';
 

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -1,5 +1,9 @@
 /**
- * @see https://www.w3.org/TR/2014/WD-encrypted-media-20140218
+ * The W3C Working Draft of 22 October 2013 seems to be the best match for
+ * the ms-prefixed API. However, it should only be used as a guide; it is
+ * doubtful the spec is 100% implemented as described.
+ * @see https://www.w3.org/TR/2013/WD-encrypted-media-20131022
+ * @see https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/mt598601(v=vs.85)
  */
 import window from 'global/window';
 import { requestPlayreadyLicense } from './playready';

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -89,6 +89,12 @@ export const createSession = (video, initData, options, eventBus) => {
     });
   });
 
+  session.addEventListener('mskeyadded', () => {
+    eventBus.trigger({
+      target: session,
+      type: 'mskeyadded'
+    });
+  });
 };
 
 export default ({video, initData, options, eventBus}) => {

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -15,6 +15,7 @@ export const addKeyToSession = (options, session, event, eventBus) => {
         if (err) {
           eventBus.trigger({
             message: 'Unable to get key: ' + err,
+            target: session,
             type: 'mskeyerror'
           });
           return;
@@ -38,6 +39,7 @@ export const addKeyToSession = (options, session, event, eventBus) => {
     if (err) {
       eventBus.trigger({
         message: 'Unable to request key from url: ' + url,
+        target: session,
         type: 'mskeyerror'
       });
       return;
@@ -82,6 +84,7 @@ export const createSession = (video, initData, options, eventBus) => {
     eventBus.trigger({
       message: 'Unexpected key error from key session with ' +
       `code: ${session.error.code} and systemCode: ${session.error.systemCode}`,
+      target: session,
       type: 'mskeyerror'
     });
   });

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -56,16 +56,8 @@ export const addKeyToSession = (options, session, event, eventBus) => {
 export const createSession = (video, initData, options, eventBus) => {
   let session;
 
-  try {
-    // Note: invalid mime type passed here throws a NotSupportedError
-    session = video.msKeys.createSession('video/mp4', initData);
-  } catch (error) {
-    if (error.description === 'Invalid argument.') {
-      throw new Error('Invalid initData');
-    } else {
-      throw error;
-    }
-  }
+  // Note: invalid mime type passed here throws a NotSupportedError
+  session = video.msKeys.createSession('video/mp4', new Uint8Array([1,2,3,4,5,5]));
 
   if (!session) {
     throw new Error('Could not create key session.');

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -54,10 +54,8 @@ export const addKeyToSession = (options, session, event, eventBus) => {
 };
 
 export const createSession = (video, initData, options, eventBus) => {
-  let session;
-
   // Note: invalid mime type passed here throws a NotSupportedError
-  session = video.msKeys.createSession('video/mp4', new Uint8Array([1,2,3,4,5,5]));
+  const session = video.msKeys.createSession('video/mp4', initData);
 
   if (!session) {
     throw new Error('Could not create key session.');

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -255,6 +255,7 @@ const onPlayerReady = (player) => {
     }
   });
   player.tech_.on('mskeyerror', emeError);
+  // TODO: refactor this plugin so it can use a plugin dispose
   player.on('dispose', () => {
     player.tech_.off('mskeyerror', emeError);
   });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -184,7 +184,7 @@ export const setupSessions = (player) => {
  */
 export const emeErrorHandler = (player) => {
   return (objOrErr) => {
-    const message = objOrErr ? objOrErr.message || objOrErr : undefined;
+    const message = objOrErr ? objOrErr.message || objOrErr : null;
 
     player.error({
       // MEDIA_ERR_ENCRYPTED is code 5

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -303,7 +303,7 @@ const eme = function(options = {}) {
       // fake an encrypted event for handleEncryptedEvent
       const mockEncryptedEvent = {
         initDataType: 'cenc',
-        initData: new Uint8Array(),
+        initData: null,
         target: player.tech_.el_
       };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -181,11 +181,11 @@ export const setupSessions = (player) => {
  * Construct a simple function that can be used to dispatch EME errors on the
  * player directly, such as providing it to a `.catch()`.
  *
- * @function makeErrorHandler
+ * @function emeErrorHandler
  * @param    {Player} player
  * @return   {Function}
  */
-export const makeErrorHandler = (player) => {
+export const emeErrorHandler = (player) => {
   return (objOrErr) => {
     const message = objOrErr ? objOrErr.message || objOrErr : undefined;
 
@@ -212,7 +212,7 @@ const onPlayerReady = (player) => {
     return;
   }
 
-  const emeError = makeErrorHandler(player);
+  const emeError = emeErrorHandler(player);
 
   setupSessions(player);
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -222,6 +222,7 @@ const onPlayerReady = (player) => {
     // TODO convert to videojs.log.debug and add back in
     // https://github.com/videojs/video.js/pull/4780
     // videojs.log('eme', 'Received an \'encrypted\' event');
+    setupSessions(player);
     handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player.tech_)
       .catch(emeError);
   });
@@ -234,6 +235,7 @@ const onPlayerReady = (player) => {
 
     // TODO it's possible that the video state must be cleared if reusing the same video
     // element between sources
+    setupSessions(player);
     handleWebKitNeedKeyEvent(event, getOptions(player), player.tech_)
       .catch(emeError);
   });
@@ -248,6 +250,7 @@ const onPlayerReady = (player) => {
     // TODO convert to videojs.log.debug and add back in
     // https://github.com/videojs/video.js/pull/4780
     // videojs.log('eme', 'Received an \'msneedkey\' event');
+    setupSessions(player);
     try {
       handleMsNeedKeyEvent(event, getOptions(player), player.eme.sessions, player.tech_);
     } catch (error) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -242,6 +242,10 @@ const onPlayerReady = (player, emeError) => {
   }
 
   // IE11 Windows 8.1+
+  // Since IE11 doesn't support promises, we have to use a combination of
+  // try/catch blocks and event handling to simulate promise rejection.
+  // Functionally speaking, there should be no discernible difference between
+  // the behavior of IE11 and those of other browsers.
   player.tech_.el_.addEventListener('msneedkey', (event) => {
     // TODO convert to videojs.log.debug and add back in
     // https://github.com/videojs/video.js/pull/4780

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -303,7 +303,7 @@ const eme = function(options = {}) {
       // fake an encrypted event for handleEncryptedEvent
       const mockEncryptedEvent = {
         initDataType: 'cenc',
-        initData: null,
+        initData: new Uint8Array(),
         target: player.tech_.el_
       };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -289,8 +289,9 @@ const eme = function(options = {}) {
     * @param    {Object} [emeOptions={}]
     *           An object of eme plugin options.
     * @param    {Function} [callback=function(){}]
+    * @param    {Boolean} [suppressErrorIfPossible=false]
     */
-    initializeMediaKeys(emeOptions = {}, callback = function() {}) {
+    initializeMediaKeys(emeOptions = {}, callback = function() {}, suppressErrorIfPossible = false) {
       // TODO: this should be refactored and renamed to be less tied
       // to encrypted events
       const mergedEmeOptions = videojs.mergeOptions(
@@ -312,7 +313,8 @@ const eme = function(options = {}) {
         handleEncryptedEvent(mockEncryptedEvent, mergedEmeOptions, player.eme.sessions, player.tech_)
           .then(() => callback())
           .catch((error) => {
-            if (callback(error) !== false) {
+            callback(error);
+            if (!suppressErrorIfPossible) {
               emeError(error);
             }
           });
@@ -321,8 +323,9 @@ const eme = function(options = {}) {
           player.tech_.off('mskeyadded', msKeyHandler);
           player.tech_.off('mskeyerror', msKeyHandler);
           if (event.type === 'mskeyerror') {
-            if (callback(event.target.error) !== false) {
-              emeError(event.target.error);
+            callback(event.target.error);
+            if (!suppressErrorIfPossible) {
+              emeError(event.message);
             }
           } else {
             callback();
@@ -336,7 +339,8 @@ const eme = function(options = {}) {
         } catch (error) {
           player.tech_.off('mskeyadded', msKeyHandler);
           player.tech_.off('mskeyerror', msKeyHandler);
-          if (callback(error) !== false) {
+          callback(error);
+          if (!suppressErrorIfPossible) {
             emeError(error);
           }
         }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -187,6 +187,7 @@ export const emeErrorHandler = (player) => {
     const message = objOrErr ? objOrErr.message || objOrErr : undefined;
 
     player.error({
+      // MEDIA_ERR_ENCRYPTED is code 5
       code: 5,
       message
     });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -114,9 +114,6 @@ export const handleMsNeedKeyEvent = (event, options, sessions, eventBus) => {
     // return silently since it may be handled by a different system
     return;
   }
-  if (event.initData === null) {
-    return;
-  }
 
   // "With PlayReady content protection, your Web app must handle the first needKey event,
   // but it must then ignore any other needKey event that occurs."

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -500,7 +500,6 @@ QUnit.test('getSupportedKeySystem error', function(assert) {
     assert.equal(err.name, 'NotSupportedError', 'keysystem access request fails');
     done();
   });
-
 });
 
 QUnit.test('errors when neither url nor getLicense is given', function(assert) {

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -669,14 +669,13 @@ QUnit.test('rejects promise when setMediaKeys rejects', function(assert) {
 
 });
 
-// For some reason this test does not work
-QUnit.skip('getLicense promise rejection', function(assert) {
+QUnit.test('getLicense promise rejection', function(assert) {
   const options = {
     keySystems: {
       'com.widevine.alpha': {
         url: 'some-url',
-        getLicense() {
-          return Promise.reject();
+        getLicense(emeOptions, keyMessage, callback) {
+          callback('error getting license');
         }
       }
     }
@@ -710,20 +709,19 @@ QUnit.skip('getLicense promise rejection', function(assert) {
     keySystemAccess,
     options
   }).catch((err) => {
-    assert.equal(err, 'test', 'test');
+    assert.equal(err, 'error getting license', 'correct error message');
     done();
   });
 
 });
 
-// For some reason this test does not work
-QUnit.skip('keySession.update promise rejection', function(assert) {
+QUnit.test('keySession.update promise rejection', function(assert) {
   const options = {
     keySystems: {
       'com.widevine.alpha': {
         url: 'some-url',
-        getLicense() {
-          return Promise.resolve();
+        getLicense(emeOptions, keyMessage, callback) {
+          callback(null, 'license');
         }
       }
     }
@@ -742,7 +740,7 @@ QUnit.skip('keySession.update promise rejection', function(assert) {
             },
             keyStatuses: [],
             generateRequest: () => Promise.resolve(),
-            update: () => Promise.reject()
+            update: () => Promise.reject('keySession update failed')
           };
         }
       });
@@ -758,7 +756,7 @@ QUnit.skip('keySession.update promise rejection', function(assert) {
     keySystemAccess,
     options
   }).catch((err) => {
-    assert.equal(err, 'test', 'test');
+    assert.equal(err, 'keySession update failed', 'correct error message');
     done();
   });
 

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -350,8 +350,9 @@ QUnit.test('accepts a license URL as property', function(assert) {
 });
 
 QUnit.test('5 July 2016 lifecycle', function(assert) {
-  assert.expect(32);
+  assert.expect(33);
 
+  let errors = 0;
   const done = assert.async();
   const callbacks = {};
   const callCounts = {
@@ -411,6 +412,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
         },
         update: () => {
           callCounts.keySessionUpdate++;
+          return Promise.resolve();
         }
       };
     }
@@ -431,7 +433,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
     keySystemAccess,
     options,
     eventBus
-  }).catch((e) => {});
+  }).then(() => done()).catch(() => errors++);
 
   // Step 1: get certificate
   assert.equal(callCounts.getCertificate, 1, 'certificate requested');
@@ -486,8 +488,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
       assert.equal(callCounts.keySessionUpdate, 1, 'key session updated');
       assert.equal(callCounts.licenseRequestAttempts, 1,
         'license request event triggered');
-
-      done();
+      assert.equal(errors, 0, 'no errors occurred');
     });
   });
 });

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -212,7 +212,7 @@ QUnit.test('error in webkitKeys.createSession rejects promise', function(assert)
   keySystems[FAIRPLAY_KEY_SYSTEM] = {};
 
   fairplay({video, initData, options: {keySystems}}).catch(err => {
-    assert.equal(err, 'Could not create key session: invalid mimeType or initData',
+    assert.equal(err, 'Could not create key session',
       'message is good');
     done();
   });

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
-
-import fairplay from '../src/fairplay';
+import {default as fairplay, FAIRPLAY_KEY_SYSTEM} from '../src/fairplay';
+import window from 'global/window';
 
 QUnit.module('videojs-contrib-eme fairplay');
 
@@ -132,4 +132,138 @@ QUnit.test('lifecycle', function(assert) {
 
     keySessionEventListeners.webkitkeyadded();
   };
+});
+
+QUnit.test('error in getCertificate rejects promise', function(assert) {
+  const keySystems = {};
+  const done = assert.async(1);
+
+  keySystems[FAIRPLAY_KEY_SYSTEM] = {
+    getCertificate: (options, callback) => {
+      callback('error in getCertificate');
+    }
+  };
+
+  fairplay({options: {keySystems}}).catch((err) => {
+    assert.equal(err, 'error in getCertificate', 'message is good');
+    done();
+  });
+
+});
+
+QUnit.test('error in webkitSetMediaKeys rejects promise', function(assert) {
+  const keySystems = {};
+  const done = assert.async(1);
+  const initData = new Uint8Array([1, 2, 3, 4]).buffer;
+  const video = {
+    webkitSetMediaKeys: () => {}
+  };
+
+  window.WebKitMediaKeys = () => {};
+
+  keySystems[FAIRPLAY_KEY_SYSTEM] = {};
+
+  fairplay({video, initData, options: {keySystems}}).catch(err => {
+    assert.equal(err, 'Could not create MediaKeys', 'message is good');
+    done();
+  });
+
+});
+
+QUnit.test('error in webkitKeys.createSession rejects promise', function(assert) {
+  const keySystems = {};
+  const done = assert.async(1);
+  const initData = new Uint8Array([1, 2, 3, 4]).buffer;
+  const video = {
+    webkitSetMediaKeys: () => {
+      video.webkitKeys = {
+        createSession: () => null
+      };
+    }
+  };
+
+  window.WebKitMediaKeys = () => {};
+
+  keySystems[FAIRPLAY_KEY_SYSTEM] = {};
+
+  fairplay({video, initData, options: {keySystems}}).catch(err => {
+    assert.equal(err, 'Could not create key session', 'message is good');
+    done();
+  });
+
+});
+
+QUnit.test('error in getLicense rejects promise', function(assert) {
+  const keySystems = {};
+  const done = assert.async(1);
+  const initData = new Uint8Array([1, 2, 3, 4]).buffer;
+  const video = {
+    webkitSetMediaKeys: () => {
+      video.webkitKeys = {
+        createSession: () => {
+          return {
+            addEventListener: (event, callback) => {
+              if (event === 'webkitkeymessage') {
+                callback({message: 'whatever'});
+              }
+            }
+          };
+        }
+      };
+    }
+  };
+
+  window.WebKitMediaKeys = () => {};
+
+  keySystems[FAIRPLAY_KEY_SYSTEM] = {
+    getLicense: (options, contentId, message, callback) => {
+      callback('error in getLicense');
+    }
+  };
+
+  fairplay({video, initData, options: {keySystems}}).catch(err => {
+    assert.equal(err, 'error in getLicense', 'message is good');
+    done();
+  });
+
+});
+
+QUnit.test('a webkitkeyerror rejects promise', function(assert) {
+  let keySession;
+  const keySystems = {};
+  const done = assert.async(1);
+  const initData = new Uint8Array([1, 2, 3, 4]).buffer;
+  const video = {
+    webkitSetMediaKeys: () => {
+      video.webkitKeys = {
+        createSession: () => {
+          return {
+            addEventListener: (event, callback) => {
+              if (event === 'webkitkeyerror') {
+                callback('webkitkeyerror');
+              }
+            }
+          };
+        }
+      };
+    }
+  };
+
+  window.WebKitMediaKeys = () => {};
+
+  keySystems[FAIRPLAY_KEY_SYSTEM] = {
+    getLicense: (options, contentId, message, callback) => {
+      callback(null);
+      keySession.trigger({
+        message: 'test',
+        type: 'webkitkeyerror'
+      });
+    }
+  };
+
+  fairplay({video, initData, options: {keySystems}}).catch(err => {
+    assert.equal(err, 'webkitkeyerror', 'message is good');
+    done();
+  });
+
 });

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -69,31 +69,6 @@ QUnit.test('error thrown when creating keys bubbles up', function(assert) {
   );
 });
 
-QUnit.test('invalid initData given to createSession throws error', function(assert) {
-  const video = {
-    msSetMediaKeys: () => {
-      video.msKeys = {
-        createSession: () => {
-          const error = new Error('Invalid argument.');
-
-          error.description = 'Invalid argument.';
-          throw error;
-        }
-      };
-    }
-  };
-
-  const fn = () => {
-    msPrefixed({video});
-  };
-
-  assert.throws(
-    fn,
-    new Error('Invalid initData'),
-    'error is thrown with proper message'
-  );
-});
-
 QUnit.test('createSession throws unknown error', function(assert) {
   const video = {
     msSetMediaKeys: () => {

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -58,12 +58,8 @@ QUnit.test('error thrown when creating keys bubbles up', function(assert) {
     throw new Error('error');
   };
 
-  const fn = () => {
-    msPrefixed({video: this.video});
-  };
-
   assert.throws(
-    fn,
+    () => msPrefixed({video: this.video}),
     new Error('Unable to create media keys for PlayReady key system. Error: error'),
     'error is thrown with proper message'
   );
@@ -80,12 +76,8 @@ QUnit.test('createSession throws unknown error', function(assert) {
     }
   };
 
-  const fn = () => {
-    msPrefixed({video});
-  };
-
   assert.throws(
-    fn,
+    () => msPrefixed({video}),
     new Error('whatever'),
     'error is thrown with proper message'
   );
@@ -100,12 +92,8 @@ QUnit.test('throws error if session was not created', function(assert) {
     }
   };
 
-  const fn = () => {
-    msPrefixed({video});
-  };
-
   assert.throws(
-    fn,
+    () => msPrefixed({video}),
     new Error('Could not create key session.'),
     'error is thrown with proper message'
   );

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -457,7 +457,7 @@ QUnit.test('handleWebKitNeedKeyEvent checks for required options', function(asse
   const promise = handleWebKitNeedKeyEvent(event, options);
 
   promise.catch((err) => {
-    assert.equal(err, 'Could not create key session: invalid mimeType or initData',
+    assert.equal(err, 'Could not create key session',
       'expected error message');
     done();
   });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -167,19 +167,22 @@ QUnit.test('initializeMediaKeys ms-prefix', function(assert) {
 
     assert.equal(sessions.length, 1, 'created a session when keySystems in options');
     assert.deepEqual(sessions[0].initData, initData, 'captured initData in the session');
-    assert.equal(error, 'some keySession error', 'callback receives error');
+    assert.notEqual(error, undefined, 'callback receives error');
 
     done();
   });
 
-  setTimeout(() => {
-    keySession.error = 'some keySession error';
-    keySession.trigger({
-      target: keySession,
-      type: 'mskeyerror'
+  if (keySession) {
+    // we stubbed the keySession
+    setTimeout(() => {
+      keySession.error = 'some keySession error';
+      keySession.trigger({
+        target: keySession,
+        type: 'mskeyerror'
+      });
     });
-  });
-  this.clock.tick(1);
+    this.clock.tick(1);
+  }
 
   this.player.tech_.el_.msSetMediaKeys = null;
   this.player.tech_.el_.setMediaKeys = setMediaKeys;

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -247,7 +247,7 @@ QUnit.test('initializeMediaKeys ms-prefix', function(assert) {
   setTimeout(() => {
     // `error` will be called on the player 3 times, because a key session
     // error can't be suppressed on IE11
-    assert.equal(errors, 3, 'error called on player twice');
+    assert.equal(errors, 3, 'error called on player 3 times');
     assert.equal(this.player.error(), null,
       'no error called on player with suppressError = true');
     done();

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -14,7 +14,7 @@ import {
   handleWebKitNeedKeyEvent,
   getOptions,
   removeSession,
-  makeErrorHandler
+  emeErrorHandler
 } from '../src/plugin';
 
 const Player = videojs.getComponent('Player');
@@ -638,7 +638,7 @@ QUnit.test('emeError properly handles various parameter types', function(assert)
       errorObj = obj;
     }
   };
-  const emeError = makeErrorHandler(player);
+  const emeError = emeErrorHandler(player);
 
   emeError(undefined);
   assert.equal(errorObj.message, undefined, 'undefined error message');

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -641,7 +641,7 @@ QUnit.test('emeError properly handles various parameter types', function(assert)
   const emeError = emeErrorHandler(player);
 
   emeError(undefined);
-  assert.equal(errorObj.message, undefined, 'undefined error message');
+  assert.equal(typeof errorObj.message, 'undefined', 'undefined error message');
 
   emeError(new Error('some error'));
   assert.equal(errorObj.message, 'some error', 'use error text when error');

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -723,7 +723,7 @@ QUnit.test('emeError properly handles various parameter types', function(assert)
   const emeError = emeErrorHandler(player);
 
   emeError(undefined);
-  assert.equal(typeof errorObj.message, 'undefined', 'undefined error message');
+  assert.equal(errorObj.message, null, 'null error message');
 
   emeError(new Error('some error'));
   assert.equal(errorObj.message, 'some error', 'use error text when error');

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -435,7 +435,8 @@ QUnit.test('handleWebKitNeedKeyEvent checks for required options', function(asse
   const promise = handleWebKitNeedKeyEvent(event, options);
 
   promise.catch((err) => {
-    assert.equal(err, 'Could not create MediaKeys', 'expected error message');
+    assert.equal(err, 'Could not create key session: invalid mimeType or initData',
+      'expected error message');
     done();
   });
   assert.ok(promise, 'returns promise when proper FairPlay key system');


### PR DESCRIPTION
Errors in EME will now fire `player.error()`. For spec-compliant EME and Safari, it's promises all the way down.

Also cleaned up the `handleEncryptedEvent` stuff; it was calling `requestMediaKeySystemAccess` twice for every `encrypted`.

Added a bunch of tests to test the various error conditions and make sure they spit out the correct error message strings.

A few things to note:

1. I am using `player.tech_` as an error event bus for IE11 since it doesn't have promises. Those events are then caught and the error handler is called.
2. The tests will fail on IE11, because promises. I may just do a batch exclude of those tests when running on IE11. (this is the same on master)
3. I do not shim `video.msSetMediaKeys` when available since it is apparently read-only and thus can't be assigned to in strict mode.
5. I removed the shimming of `window.navigator.requestMediaKeySystemAccess` in a bunch of tests because I don't think it's necessary now (so long as you're running on localhost). Let me know if you think it should be shimmed out anyway.