### PR TITLE
Support setting robustness level

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -12,17 +12,26 @@ export const getSupportedKeySystem = (keySystems) => {
     // TODO use initDataTypes when appropriate
     const systemOptions = {};
     const audioContentType = keySystems[keySystem].audioContentType;
+    const audioRobustness = keySystems[keySystem].audioRobustness;
     const videoContentType = keySystems[keySystem].videoContentType;
+    const videoRobustness = keySystems[keySystem].videoRobustness;
 
-    if (audioContentType) {
-      systemOptions.audioCapabilities = [{
-        contentType: audioContentType
-      }];
+    if (audioContentType || audioRobustness) {
+      systemOptions.audioCapabilities = [
+        Object.assign({},
+          (audioContentType ? { contentType: audioContentType } : {}),
+          (audioRobustness ? { robustness: audioRobustness } : {})
+        )
+      ];
     }
-    if (videoContentType) {
-      systemOptions.videoCapabilities = [{
-        contentType: videoContentType
-      }];
+
+    if (videoContentType || videoRobustness) {
+      systemOptions.videoCapabilities = [
+        Object.assign({},
+          (videoContentType ? { contentType: videoContentType } : {}),
+          (videoRobustness ? { robustness: videoRobustness } : {})
+        )
+      ];
     }
 
     if (!promise) {


### PR DESCRIPTION
Hi there, thanks for writing this plugin!
Currently it is not possible to pass a robustness level. This leads to warnings in chrome that unexpected behaviour can occur. I do not really care about the warnings but I only want to play streams when hardware decoding is supported. So I made a pull request.

In the native `navigator.requestMediaKeySystemAccess` the second argument is a supportedConfigurations array. In my case it is something like this:

```
[
  {
    initDataTypes: ['cenc'],
    persistentState: 'optional',
    distinctiveIdentifier: 'optional',
    sessionTypes: ['temporary'],
    audioCapabilities: [],
    videoCapabilities: [
      {
        robustness: 'HW_SECURE_ALL',
        contentType: 'video/mp4;codecs="avc1.42E01E"'
      },
    ]
  }
]
```

I am especially interested wether hardware supported decoding is supported through the robustness property, so I added a `videoRobustness` property to the `systemOptions`. That's it!

i do have one more question. How do you feel about just passing the configuration in the same format as with `navigator.requestMediaKeySystemAccess` so the mapping of `videoContentType` to `contentType` and now `videoRobustness` to `robustness` would not be necessary? Also that would solve all other missing "mappings", which would make the plugin more applicable in a broader range of configurations.

Thanks in advance!