### PR TITLE
fix: Use correct callback function signature for PlayReady license request callbacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ By default, videojs-contrib-eme is not able to decrypt any audio/video.
 
 In order to decrypt audio/video, a user must pass in either relevant license URIs, or methods specific to a source and its combination of key system and codec. These are provided to the plugin via either videojs-contrib-eme's plugin options or source options.
 
+If you're new to DRM on the web, read [about how EME is used to play protected content on the web](https://developers.google.com/web/fundamentals/media/eme).
+
 ### Initialization
 
 The videojs-contrib-eme plugin must be initialized before a source is loaded into the player:

--- a/src/playready.js
+++ b/src/playready.js
@@ -57,5 +57,12 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
     headers,
     body: message,
     responseType: 'arraybuffer'
-  }, callback);
+  }, (err, response, responseBody) => {
+    if (err) {
+      callback(err);
+      return;
+    }
+
+    callback(null, responseBody);
+  });
 };

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -184,7 +184,7 @@ QUnit.test('calls getKey when provided on key message', function(assert) {
   assert.equal(this.session.keys[0], 'a key', 'added correct key to session');
 
   getKeyCallback = (callback) => {
-    callback('an error', 'an errored key');
+    callback('an error', {}, 'an errored key');
   };
 
   this.session.trigger({
@@ -253,14 +253,14 @@ QUnit.test('makes request when nothing provided on key message', function(assert
     body: utils.stringToArrayBuffer('key value')
   };
 
-  xhrCalls[0].callback('an error', response);
+  xhrCalls[0].callback('an error', {}, response);
 
   assert.equal(errorMessage,
     'Unable to request key from url: destination-url',
     'triggers mskeyerror on event bus when callback has an error');
   assert.equal(this.session.keys.length, 0, 'no key added to session');
 
-  xhrCalls[0].callback(null, response);
+  xhrCalls[0].callback(null, {}, response);
 
   assert.equal(this.session.keys.length, 1, 'key added to session');
   assert.deepEqual(this.session.keys[0],
@@ -372,14 +372,14 @@ QUnit.test('makes request with provided url string on key message', function(ass
     body: utils.stringToArrayBuffer('key value')
   };
 
-  xhrCalls[0].callback('an error', response);
+  xhrCalls[0].callback('an error', {}, response);
 
   assert.equal(errorMessage,
     'Unable to request key from url: provided-url',
     'triggers mskeyerror on event bus when callback has an error');
   assert.equal(this.session.keys.length, 0, 'no key added to session');
 
-  xhrCalls[0].callback(null, response);
+  xhrCalls[0].callback(null, {}, response);
 
   assert.equal(this.session.keys.length, 1, 'key added to session');
   assert.deepEqual(this.session.keys[0],
@@ -456,7 +456,7 @@ QUnit.test('makes request with provided url on key message', function(assert) {
     body: utils.stringToArrayBuffer('key value')
   };
 
-  xhrCalls[0].callback('an error', response);
+  xhrCalls[0].callback('an error', {}, response);
 
   assert.equal(callCounts.licenseRequestAttempts, 1, 'license request event triggered');
   assert.equal(errorMessage,
@@ -464,7 +464,7 @@ QUnit.test('makes request with provided url on key message', function(assert) {
     'triggers mskeyerror on event bus when callback has an error');
   assert.equal(this.session.keys.length, 0, 'no key added to session');
 
-  xhrCalls[0].callback(null, response);
+  xhrCalls[0].callback(null, {}, response);
 
   assert.equal(callCounts.licenseRequestAttempts, 2,
     'second license request event triggered');


### PR DESCRIPTION
The previous code (and tests) had faulty assumptions about the callback signature of a `videojs.xhr()` call. The second argument is _not_ the `responseBody` but the `response` object.