### PR TITLE
fix: use new method signature for requestPlayreadyLicense from #81

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -173,14 +173,7 @@ const setMediaKeys = ({
 };
 
 const defaultPlayreadyGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callback) => {
-  requestPlayreadyLicense(keySystemOptions, keyMessage, emeOptions, (err, response, responseBody) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    callback(null, responseBody);
-  });
+  requestPlayreadyLicense(keySystemOptions, keyMessage, emeOptions, callback);
 };
 
 const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callback) => {


### PR DESCRIPTION
PR #81 fixed the callback signature for ms-prefixed, which was
incorrect. However, eme was being used correctly, and so the PR broke
eme support on Edge.