### PR TITLE
Fix/safari 12.1

### DIFF
--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -161,6 +161,11 @@ QUnit.test('initializeMediaKeys ms-prefix', function(assert) {
   let errors = 0;
   let keySession;
   let errorMessage;
+  const origMediaKeys = window.MediaKeys;
+  const origWebKitMediaKeys = window.WebKitMediaKeys;
+
+  window.MediaKeys = undefined;
+  window.WebKitMediaKeys = undefined;
 
   if (!window.MSMediaKeys) {
     window.MSMediaKeys = () => {};
@@ -250,6 +255,8 @@ QUnit.test('initializeMediaKeys ms-prefix', function(assert) {
     assert.equal(errors, 3, 'error called on player 3 times');
     assert.equal(this.player.error(), null,
       'no error called on player with suppressError = true');
+    window.MediaKeys = origMediaKeys;
+    window.WebKitMediaKeys = origWebKitMediaKeys;
     done();
   });
   this.clock.tick(1);
@@ -262,7 +269,14 @@ QUnit.test('tech error listener is removed on dispose', function(assert) {
   const done = assert.async(1);
   let called = 0;
   const browser = videojs.browser;
+  const origMediaKeys = window.MediaKeys;
+  const origWebKitMediaKeys = window.WebKitMediaKeys;
 
+  window.MediaKeys = undefined;
+  window.WebKitMediaKeys = undefined;
+  if (!window.MSMediaKeys) {
+    window.MSMediaKeys = noop.bind(this);
+  }
   // let this test pass on edge
   videojs.browser = {IS_EDGE: false};
 
@@ -284,6 +298,8 @@ QUnit.test('tech error listener is removed on dispose', function(assert) {
 
     this.player.error = undefined;
     videojs.browser = browser;
+    window.MediaKeys = origMediaKeys;
+    window.WebKitMediaKeys = origWebKitMediaKeys;
     done();
   });
 


### PR DESCRIPTION
[Safari 12.1 introduced in-spec EME API support on macOS 10.14.4 and iOS 12.2.](https://webkit.org/blog/8718/new-webkit-features-in-safari-12-1/)

This plugin does not support using fairplay with the standard EME API. However, it appears that Safari's EME API is broken; `navigator.requestMediaKeySystemAccess` seems to always reject. I am currently building Safari to see if I can get at [some debug logs](https://github.com/WebKit/webkit/blob/master/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp#L47). Unfortunately, the prebuilt binaries on webkit.org don't actually work, so I have a feeling my build won't work.

To bridge the gap until Safari gets its act together, this patch uses the old prefixed API if it exists.

Closes #79, #80.