### PR TITLE
Save session-specific options in pending session data when waiting on media keys

### DIFF
--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -3,7 +3,9 @@ import videojs from 'video.js';
 import {
   standard5July2016,
   makeNewRequest,
-  getSupportedKeySystem
+  getSupportedKeySystem,
+  addSession,
+  addPendingSessions
 } from '../src/eme';
 
 // mock session to make testing easier (so we can trigger events)
@@ -608,7 +610,7 @@ QUnit.test('rejects promise when createMediaKeys rejects', function(assert) {
 
 });
 
-QUnit.test('rejects promise when setMediaKeys rejects', function(assert) {
+QUnit.test('rejects promise when addPendingSessions rejects', function(assert) {
   let rejectSetServerCertificate = true;
   const rejectGenerateRequest = true;
   let rejectSetMediaKeys = true;
@@ -885,6 +887,105 @@ QUnit.test('licenseHeaders keySystems property overrides emeHeaders value', func
 
     videojs.xhr = origXhr;
 
+    done();
+  });
+});
+
+QUnit.module('session management');
+
+QUnit.test('addSession saves options', function(assert) {
+  const video = {
+    pendingSessionData: []
+  };
+  const initDataType = 'temporary';
+  const initData = new Uint8Array();
+  const options = { some: 'option' };
+  const getLicense = () => '';
+  const removeSession = () => '';
+  const eventBus = 'bus';
+
+  addSession({
+    video,
+    initDataType,
+    initData,
+    options,
+    getLicense,
+    removeSession,
+    eventBus
+  });
+
+  assert.deepEqual(
+    video.pendingSessionData,
+    [{
+      initDataType,
+      initData,
+      options,
+      getLicense,
+      removeSession,
+      eventBus
+    }],
+    'saved options into pendingSessionData array'
+  );
+});
+
+QUnit.test('addPendingSessions reuses saved options', function(assert) {
+  assert.expect(5);
+
+  const done = assert.async();
+
+  const options = { some: 'option' };
+  const getLicense = (emeOptions, message) => {
+    assert.deepEqual(emeOptions, options, 'used pending session data options');
+    return Promise.resolve('license');
+  };
+  const eventListeners = [];
+  const pendingSessionData = [{
+    initDataType: 'temporary',
+    initData: new Uint8Array(),
+    options,
+    getLicense,
+    removeSession: () => '',
+    eventBus: 'bus'
+  }];
+  const video = {
+    pendingSessionData,
+    setMediaKeys: (mediaKeys) => Promise.resolve()
+  };
+  const createdMediaKeys = {
+    createSession: () => {
+      return {
+        addEventListener: (event, callback) => eventListeners.push({ event, callback }),
+        generateRequest: (initDataType, initData) => {
+          assert.equal(
+            initDataType,
+            pendingSessionData[0].initDataType,
+            'generateRequest received correct initDataType'
+          );
+          assert.equal(
+            initData,
+            pendingSessionData[0].initData,
+            'generateRequest received correct initData'
+          );
+          assert.equal(eventListeners.length, 2, 'added two event listeners');
+          assert.equal(
+            eventListeners[0].event,
+            'message',
+            'added listener for message event'
+          );
+          // callback should call getLicense
+          eventListeners[0].callback({ message: 'test message' });
+          return Promise.resolve();
+        },
+        // this call and everything after is beyond the scope of this test
+        update: () => Promise.resolve()
+      };
+    }
+  };
+
+  return addPendingSessions({
+    video,
+    createdMediaKeys
+  }).then((resolve, reject) => {
     done();
   });
 });

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -902,7 +902,7 @@ QUnit.test('addSession saves options', function(assert) {
   const options = { some: 'option' };
   const getLicense = () => '';
   const removeSession = () => '';
-  const eventBus = 'bus';
+  const eventBus = { trigger: () => {} };
 
   addSession({
     video,
@@ -932,7 +932,6 @@ QUnit.test('addPendingSessions reuses saved options', function(assert) {
   assert.expect(5);
 
   const done = assert.async();
-
   const options = { some: 'option' };
   const getLicense = (emeOptions, message) => {
     assert.deepEqual(emeOptions, options, 'used pending session data options');
@@ -945,11 +944,12 @@ QUnit.test('addPendingSessions reuses saved options', function(assert) {
     options,
     getLicense,
     removeSession: () => '',
-    eventBus: 'bus'
+    eventBus: { trigger: () => {} }
   }];
   const video = {
     pendingSessionData,
-    setMediaKeys: (mediaKeys) => Promise.resolve()
+    // internal API, not used in this test
+    setMediaKeys: () => Promise.resolve()
   };
   const createdMediaKeys = {
     createSession: () => {
@@ -972,7 +972,7 @@ QUnit.test('addPendingSessions reuses saved options', function(assert) {
             'message',
             'added listener for message event'
           );
-          // callback should call getLicense
+          // callback should call getLicense, which continues this test
           eventListeners[0].callback({ message: 'test message' });
           return Promise.resolve();
         },


### PR DESCRIPTION
Instead of always using new options, persist options passed when adding session data to the pendingSessionData array to allow for different options per session created.

This fixes cases where two encrypted pieces of media are in the same manifest, and a user set up the sessions in advance using `initializeMediaKeys`. Previously, the newest options would be used for all sessions. This provides the relevant options.

## Testing

Because this case occurs when the same manifest has content with different keys, finding a source for testing is a bit of a challenge. I was able to combine two clear key encrypted sources into one manifest using https://github.com/gesinger/encrypted-video-creator, and can share the instructions/content, but the general steps are:

1) Run the script using default options on a source two times (with different destinations)
2) Combine the audio/video stream manifests, adding an `EXT-X-DISCONTINUITY` tag in-between where one media ends and the other begins
3) Combine the sample-code.js files by copying the `keys` array over as `keys2` (or some more appropriate name), and the `getLicense` function as `getLicense2`, then `initializeMediaKeys` separately for each