### PR TITLE
feat: getLicense should pass an error to callback if XHR returns 400/500

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Maintenance Status: Stable
   - [Other DRM Systems](#other-drm-systems)
     - [Get License By URL](#get-license-by-url)
     - [Get License By Function](#get-license-by-function)
+  - [A Note on Get License Callbacks](#a-note-on-get-license-callbacks)
 - [API](#api)
   - [Available Options](#available-options)
     - [`keySystems`](#keysystems)
@@ -278,6 +279,10 @@ Below is an example of using one of these DRM systems and custom `getLicense()` 
 }
 ```
 
+### A Note on Get License Callbacks
+
+The default `getLicense()` functions pass an error to the callback if the license request returns a 4xx or 5xx response code. Depending on how the license server is configured, it is possible in some cases that a valid license could still be returned even if the response code is in that range. If you wish not to pass an error for 4xx and 5xx response codes, you may pass your own `getLicense()` function with the `keySystems` as described above.
+
 ## API
 
 ### Available Options
@@ -490,7 +495,7 @@ When `suppressErrorsIfPossible` is set to `false` (the default) and an error occ
 
 ### Events
 
-There are some events that are specific to this plugin. 
+There are some events that are specific to this plugin.
 
 #### `licenserequestattempted`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Maintenance Status: Stable
   - [Other DRM Systems](#other-drm-systems)
     - [Get License By URL](#get-license-by-url)
     - [Get License By Function](#get-license-by-function)
-  - [A Note on Get License Callbacks](#a-note-on-get-license-callbacks)
+  - [Get License Errors](#get-license-errors)
 - [API](#api)
   - [Available Options](#available-options)
     - [`keySystems`](#keysystems)
@@ -279,7 +279,7 @@ Below is an example of using one of these DRM systems and custom `getLicense()` 
 }
 ```
 
-### A Note on Get License Callbacks
+### Get License Errors
 
 The default `getLicense()` functions pass an error to the callback if the license request returns a 4xx or 5xx response code. Depending on how the license server is configured, it is possible in some cases that a valid license could still be returned even if the response code is in that range. If you wish not to pass an error for 4xx and 5xx response codes, you may pass your own `getLicense()` function with the `keySystems` as described above.
 

--- a/src/eme.js
+++ b/src/eme.js
@@ -195,6 +195,14 @@ const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callbac
       return;
     }
 
+    if (response.statusCode >= 400 && response.statusCode <= 599) {
+      callback({
+        message: `License request failed with response code ${response.statusCode}`,
+        statusCode: response.statusCode
+      });
+      return;
+    }
+
     callback(null, responseBody);
   });
 };

--- a/src/eme.js
+++ b/src/eme.js
@@ -196,10 +196,8 @@ const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callbac
     }
 
     if (response.statusCode >= 400 && response.statusCode <= 599) {
-      callback({
-        message: `License request failed with response code ${response.statusCode}`,
-        statusCode: response.statusCode
-      });
+      // Pass an empty object as the error to use the default code 5 error message
+      callback({});
       return;
     }
 

--- a/src/eme.js
+++ b/src/eme.js
@@ -176,7 +176,7 @@ const defaultPlayreadyGetLicense = (keySystemOptions) => (emeOptions, keyMessage
   requestPlayreadyLicense(keySystemOptions, keyMessage, emeOptions, callback);
 };
 
-const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callback) => {
+export const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, callback) => {
   const headers = mergeAndRemoveNull(
     {'Content-type': 'application/octet-stream'},
     emeOptions.emeHeaders,

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -146,10 +146,8 @@ export const defaultGetLicense = (fairplayOptions) => {
       }
 
       if (response.statusCode >= 400 && response.statusCode <= 599) {
-        callback({
-          message: `License request failed with response code ${response.statusCode}`,
-          statusCode: response.statusCode
-        });
+        // Pass an empty object as the error to use the default code 5 error message
+        callback({});
         return;
       }
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -145,6 +145,14 @@ export const defaultGetLicense = (fairplayOptions) => {
         return;
       }
 
+      if (response.statusCode >= 400 && response.statusCode <= 599) {
+        callback({
+          message: `License request failed with response code ${response.statusCode}`,
+          statusCode: response.statusCode
+        });
+        return;
+      }
+
       callback(null, responseBody);
     });
   };

--- a/src/playready.js
+++ b/src/playready.js
@@ -63,6 +63,14 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
       return;
     }
 
+    if (response.statusCode >= 400 && response.statusCode <= 599) {
+      callback({
+        message: `License request failed with response code ${response.statusCode}`,
+        statusCode: response.statusCode
+      });
+      return;
+    }
+
     callback(null, responseBody);
   });
 };

--- a/src/playready.js
+++ b/src/playready.js
@@ -64,10 +64,8 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
     }
 
     if (response.statusCode >= 400 && response.statusCode <= 599) {
-      callback({
-        message: `License request failed with response code ${response.statusCode}`,
-        statusCode: response.statusCode
-      });
+      // Pass an empty object as the error to use the default code 5 error message
+      callback({});
       return;
     }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -185,13 +185,12 @@ export const setupSessions = (player) => {
  */
 export const emeErrorHandler = (player) => {
   return (objOrErr) => {
-    const message = objOrErr ? objOrErr.message || objOrErr : null;
+    const message = typeof objOrErr === 'string' ? objOrErr : (objOrErr && objOrErr.message) || null;
 
     player.error({
       // MEDIA_ERR_ENCRYPTED is code 5
       code: 5,
-      message,
-      originalError: objOrErr
+      message
     });
   };
 };

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -190,7 +190,8 @@ export const emeErrorHandler = (player) => {
     player.error({
       // MEDIA_ERR_ENCRYPTED is code 5
       code: 5,
-      message
+      message,
+      originalError: objOrErr
     });
   };
 };
@@ -294,7 +295,7 @@ const eme = function(options = {}) {
     * @param    {Object} [emeOptions={}]
     *           An object of eme plugin options.
     * @param    {Function} [callback=function(){}]
-    * @param    {Boolean} [suppressErrorIfPossible=false]
+    * @param    {boolean} [suppressErrorIfPossible=false]
     */
     initializeMediaKeys(emeOptions = {}, callback = function() {}, suppressErrorIfPossible = false) {
       // TODO: this should be refactored and renamed to be less tied

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -741,6 +741,9 @@ QUnit.test('emeError properly handles various parameter types', function(assert)
   emeError(undefined);
   assert.equal(errorObj.message, null, 'null error message');
 
+  emeError({});
+  assert.equal(errorObj.message, null, 'null error message');
+
   emeError(new Error('some error'));
   assert.equal(errorObj.message, 'some error', 'use error text when error');
 


### PR DESCRIPTION
## Description
Currently the default `getLicense()` functions are permissive in that they won't pass an error to the callback if the request returns something in the 4/500 range. The reason being that in some cases, a license server might return a valid license even if the server sends a code in that range.

We decided it makes sense to change the default behavior to callback with an error for such status codes. If a developer wants to use the old behavior, they can override the default `getLicense()` function by passing their own with `keySystems`.

## Specific additions

For status codes >= 400 && <= 599, an empty object is passed as the error (`callback({})`) and `emeError()` has been modified to call `player.error({code: 5, message: null})` in that case, which will use the default `MEDIA_ERR_ENCRYPTED` message ("The media is encrypted and we do not have the keys to decrypt it.")