### PR TITLE
fix: only getLicense on license-request or license-renewal

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -87,6 +87,10 @@ export const makeNewRequest = ({
   return new Promise((resolve, reject) => {
 
     keySession.addEventListener('message', (event) => {
+      // all other types will be handled by keystatuseschange
+      if (event.messageType !== 'license-request' && event.messageType !== 'license-renewal') {
+        return;
+      }
       getLicense(options, event.message)
         .then((license) => {
           resolve(keySession.update(license));


### PR DESCRIPTION
As per https://www.w3.org/TR/encrypted-media/#dom-mediakeymessagetype there are messageTypes that do not re-request the license.