### PR TITLE
fix: try to re-request key if the session expired

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -73,15 +73,16 @@ export const getSupportedKeySystem = (keySystems) => {
   return promise;
 };
 
-export const makeNewRequest = ({
-  mediaKeys,
-  initDataType,
-  initData,
-  options,
-  getLicense,
-  removeSession,
-  eventBus
-}) => {
+export const makeNewRequest = (requestOptions) => {
+  const {
+    mediaKeys,
+    initDataType,
+    initData,
+    options,
+    getLicense,
+    removeSession,
+    eventBus
+  } = requestOptions;
   const keySession = mediaKeys.createSession();
 
   return new Promise((resolve, reject) => {
@@ -140,6 +141,7 @@ export const makeNewRequest = ({
         // videojs.log.debug('Session expired, closing the session.');
         keySession.close().then(() => {
           removeSession(initData);
+          makeNewRequest(requestOptions);
         });
       }
     }, false);

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -139,7 +139,7 @@ QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key'
 
 });
 
-QUnit.test('keystatuseschange with expired key closes session', function(assert) {
+QUnit.test('keystatuseschange with expired key closes and recreates session', function(assert) {
   const removeSessionCalls = [];
   // once the eme module gets the removeSession function, the session argument is already
   // bound to the function (note that it's a custom session maintained by the plugin, not
@@ -150,10 +150,15 @@ QUnit.test('keystatuseschange with expired key closes session', function(assert)
   const eventBus = {
     trigger: (name) => {}
   };
+  let creates = 0;
 
   makeNewRequest({
     mediaKeys: {
-      createSession: () => mockSession
+      createSession: () => {
+        creates++;
+
+        return mockSession;
+      }
     },
     initDataType: '',
     initData,
@@ -163,6 +168,7 @@ QUnit.test('keystatuseschange with expired key closes session', function(assert)
     eventBus
   });
 
+  assert.equal(creates, 1, 'created session');
   assert.equal(mockSession.listeners.length, 2, 'added listeners');
   assert.equal(mockSession.listeners[1].type,
     'keystatuseschange',
@@ -190,6 +196,8 @@ QUnit.test('keystatuseschange with expired key closes session', function(assert)
   // synchronously
   assert.equal(removeSessionCalls.length, 1, 'called remove session');
   assert.equal(removeSessionCalls[0], initData, 'called to remove session with initData');
+
+  assert.equal(creates, 2, 'created another session');
 });
 
 QUnit.test('keystatuseschange with internal-error logs a warning', function(assert) {


### PR DESCRIPTION
Re request the key when the session is expired. This fixes multiple potential issues:
1. The tab was throttled in the background or completely paused, causing the key to never be re-requested.
2. The key request timing was a little off in the server that is being used, causing the session to expire.
3. The request for the key to renew generally takes too long and expires before we renew it.

I don't think we should have any problems doing this because if the user no longer has access to the key or we fail to get the key after expiration then we will still fail to create a new session. If they do still have access though we will get a new session and continue playback as expected.