### PR TITLE
feat: on license request errors, return response body as cause

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -292,7 +292,6 @@ export const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, 
 
     if (response.statusCode >= 400 && response.statusCode <= 599) {
       const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
-      // Pass an empty object as the error to use the default code 5 error message
 
       callback({cause});
       return;

--- a/src/eme.js
+++ b/src/eme.js
@@ -2,6 +2,7 @@ import videojs from 'video.js';
 import { requestPlayreadyLicense } from './playready';
 import window from 'global/window';
 import {mergeAndRemoveNull} from './utils';
+import {httpResponseHandler} from './http-handler.js';
 
 /**
  * Returns an array of MediaKeySystemConfigurationObjects provided in the keySystem
@@ -284,21 +285,8 @@ export const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, 
     responseType: 'arraybuffer',
     body: keyMessage,
     headers
-  }, (err, response, responseBody) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    if (response.statusCode >= 400 && response.statusCode <= 599) {
-      const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
-
-      callback({cause});
-      return;
-    }
-
-    callback(null, responseBody);
-  });
+  }, httpResponseHandler(callback)
+  );
 };
 
 const promisifyGetLicense = (getLicenseFn, eventBus) => {

--- a/src/eme.js
+++ b/src/eme.js
@@ -291,8 +291,10 @@ export const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, 
     }
 
     if (response.statusCode >= 400 && response.statusCode <= 599) {
+      const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
       // Pass an empty object as the error to use the default code 5 error message
-      callback({});
+
+      callback({cause});
       return;
     }
 

--- a/src/eme.js
+++ b/src/eme.js
@@ -285,7 +285,7 @@ export const defaultGetLicense = (keySystemOptions) => (emeOptions, keyMessage, 
     responseType: 'arraybuffer',
     body: keyMessage,
     headers
-  }, httpResponseHandler(callback)
+  }, httpResponseHandler(callback, true)
   );
 };
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -118,6 +118,13 @@ export const defaultGetCertificate = (fairplayOptions) => {
         return;
       }
 
+      if (response.statusCode >= 400 && response.statusCode <= 599) {
+        const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
+
+        callback({cause});
+        return;
+      }
+
       callback(null, new Uint8Array(responseBody));
     });
   };
@@ -148,8 +155,9 @@ export const defaultGetLicense = (fairplayOptions) => {
       }
 
       if (response.statusCode >= 400 && response.statusCode <= 599) {
-        // Pass an empty object as the error to use the default code 5 error message
-        callback({});
+        const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
+
+        callback({cause});
         return;
       }
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -120,6 +120,7 @@ export const defaultGetCertificate = (fairplayOptions) => {
       }
 
       // in this case, license is still the raw ArrayBuffer,
+      // (we don't want httpResponseHandler to decode it)
       // convert it into Uint8Array as expected
       callback(null, new Uint8Array(license));
     }));
@@ -144,7 +145,7 @@ export const defaultGetLicense = (fairplayOptions) => {
       responseType: 'arraybuffer',
       body: keyMessage,
       headers
-    }, httpResponseHandler(callback));
+    }, httpResponseHandler(callback, true));
   };
 };
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -7,6 +7,7 @@
 import videojs from 'video.js';
 import window from 'global/window';
 import {stringToUint16Array, uint8ArrayToString, getHostnameFromUri, mergeAndRemoveNull} from './utils';
+import {httpResponseHandler} from './http-handler.js';
 
 export const FAIRPLAY_KEY_SYSTEM = 'com.apple.fps.1_0';
 
@@ -112,21 +113,16 @@ export const defaultGetCertificate = (fairplayOptions) => {
       uri: fairplayOptions.certificateUri,
       responseType: 'arraybuffer',
       headers
-    }, (err, response, responseBody) => {
+    }, httpResponseHandler((err, license) => {
       if (err) {
         callback(err);
         return;
       }
 
-      if (response.statusCode >= 400 && response.statusCode <= 599) {
-        const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
-
-        callback({cause});
-        return;
-      }
-
-      callback(null, new Uint8Array(responseBody));
-    });
+      // in this case, license is still the raw ArrayBuffer,
+      // convert it into Uint8Array as expected
+      callback(null, new Uint8Array(license));
+    }));
   };
 };
 
@@ -148,21 +144,7 @@ export const defaultGetLicense = (fairplayOptions) => {
       responseType: 'arraybuffer',
       body: keyMessage,
       headers
-    }, (err, response, responseBody) => {
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      if (response.statusCode >= 400 && response.statusCode <= 599) {
-        const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
-
-        callback({cause});
-        return;
-      }
-
-      callback(null, responseBody);
-    });
+    }, httpResponseHandler(callback));
   };
 };
 

--- a/src/http-handler.js
+++ b/src/http-handler.js
@@ -12,7 +12,7 @@ export const httpResponseHandler = (callback) => (err, response, responseBody) =
     let cause;
 
     if (window.TextDecoder) {
-      const charset = getCharset(response.headers['content-type']);
+      const charset = getCharset(response.headers && response.headers['content-type']);
 
       cause = new TextDecoder(charset).decode(responseBody);
     } else {
@@ -27,7 +27,7 @@ export const httpResponseHandler = (callback) => (err, response, responseBody) =
   callback(null, responseBody);
 };
 
-function getCharset(contentTypeHeader) {
+function getCharset(contentTypeHeader = '') {
   return contentTypeHeader
     .toLowerCase()
     .split(';')

--- a/src/http-handler.js
+++ b/src/http-handler.js
@@ -1,0 +1,43 @@
+import window from 'global/window';
+
+export const httpResponseHandler = (callback) => (err, response, responseBody) => {
+  // if the XHR failed, return that error
+  if (err) {
+    callback(err);
+    return;
+  }
+
+  // if the HTTP status code is 4xx or 5xx, the request also failed
+  if (response.statusCode >= 400 && response.statusCode <= 599) {
+    let cause;
+
+    if (window.TextDecoder) {
+      const charset = getCharset(response.headers['content-type']);
+
+      cause = new TextDecoder(charset).decode(responseBody);
+    } else {
+      cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
+    }
+
+    callback({cause});
+    return;
+  }
+
+  // otherwise, request succeeded
+  callback(null, responseBody);
+};
+
+function getCharset(contentTypeHeader) {
+  return contentTypeHeader
+    .toLowerCase()
+    .split(';')
+    .reduce((charset, contentType) => {
+      const [type, value] = contentType.split('=');
+
+      if (type.trim() === 'charset') {
+        return value.trim();
+      }
+
+      return charset;
+    }, 'utf-8');
+}

--- a/src/playready.js
+++ b/src/playready.js
@@ -58,5 +58,5 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
     headers,
     body: message,
     responseType: 'arraybuffer'
-  }, httpResponseHandler(callback));
+  }, httpResponseHandler(callback, true));
 };

--- a/src/playready.js
+++ b/src/playready.js
@@ -1,6 +1,7 @@
 import videojs from 'video.js';
 import window from 'global/window';
 import {mergeAndRemoveNull} from './utils';
+import {httpResponseHandler} from './http-handler.js';
 
 /**
  * Parses the EME key message XML to extract HTTP headers and the Challenge element to use
@@ -57,19 +58,5 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
     headers,
     body: message,
     responseType: 'arraybuffer'
-  }, (err, response, responseBody) => {
-    if (err) {
-      callback(err);
-      return;
-    }
-
-    if (response.statusCode >= 400 && response.statusCode <= 599) {
-      const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
-
-      callback({cause});
-      return;
-    }
-
-    callback(null, responseBody);
-  });
+  }, httpResponseHandler(callback));
 };

--- a/src/playready.js
+++ b/src/playready.js
@@ -64,8 +64,9 @@ export const requestPlayreadyLicense = (keySystemOptions, messageBuffer, emeOpti
     }
 
     if (response.statusCode >= 400 && response.statusCode <= 599) {
-      // Pass an empty object as the error to use the default code 5 error message
-      callback({});
+      const cause = String.fromCharCode.apply(null, new Uint8Array(responseBody));
+
+      callback({cause});
       return;
     }
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -185,13 +185,23 @@ export const setupSessions = (player) => {
  */
 export const emeErrorHandler = (player) => {
   return (objOrErr) => {
-    const message = typeof objOrErr === 'string' ? objOrErr : (objOrErr && objOrErr.message) || null;
-
-    player.error({
+    const error = {
       // MEDIA_ERR_ENCRYPTED is code 5
-      code: 5,
-      message
-    });
+      code: 5
+    };
+
+    if (typeof objOrErr === 'string') {
+      error.message = objOrErr;
+    } else if (objOrErr) {
+      if (objOrErr.message) {
+        error.message = objOrErr.message;
+      }
+      if (objOrErr.cause && objOrErr.cause.length) {
+        error.cause = objOrErr.cause;
+      }
+    }
+
+    player.error(error);
   };
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -196,7 +196,9 @@ export const emeErrorHandler = (player) => {
       if (objOrErr.message) {
         error.message = objOrErr.message;
       }
-      if (objOrErr.cause && objOrErr.cause.length) {
+      if (objOrErr.cause &&
+          (objOrErr.cause.length ||
+           objOrErr.cause.byteLength)) {
         error.cause = objOrErr.cause;
       }
     }

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -797,26 +797,37 @@ QUnit.test('getLicense calls back with error for 400 and 500 status codes', func
   const getLicenseCallback = sinon.spy();
   const getLicense = defaultGetLicense({});
 
+  function toArrayBuffer(obj) {
+    const json = JSON.stringify(obj);
+    const buffer = new ArrayBuffer(json.length);
+    const bufferView = new Uint8Array(buffer);
+
+    for (let i = 0; i < json.length; i++) {
+      bufferView[i] = json.charCodeAt(i);
+    }
+    return buffer;
+  }
+
   videojs.xhr = (params, callback) => {
-    return callback(null, {statusCode: 400}, {body: 'some-body'});
+    return callback(null, {statusCode: 400}, toArrayBuffer({body: 'some-body'}));
   };
 
   getLicense({}, null, getLicenseCallback);
 
   videojs.xhr = (params, callback) => {
-    return callback(null, {statusCode: 500}, {body: 'some-body'});
+    return callback(null, {statusCode: 500}, toArrayBuffer({body: 'some-body'}));
   };
 
   getLicense({}, null, getLicenseCallback);
 
   videojs.xhr = (params, callback) => {
-    return callback(null, {statusCode: 599}, {body: 'some-body'});
+    return callback(null, {statusCode: 599}, toArrayBuffer({body: 'some-body'}));
   };
 
   getLicense({}, null, getLicenseCallback);
 
   assert.equal(getLicenseCallback.callCount, 3, 'correct callcount');
-  assert.equal(getLicenseCallback.alwaysCalledWith({}), true, 'getLicense callback called with correct error');
+  assert.ok(getLicenseCallback.alwaysCalledWith({}), 'getLicense callback called with correct error');
 });
 
 QUnit.test('getLicense calls back with response body for non-400/500 status codes', function(assert) {

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -827,7 +827,9 @@ QUnit.test('getLicense calls back with error for 400 and 500 status codes', func
   getLicense({}, null, getLicenseCallback);
 
   assert.equal(getLicenseCallback.callCount, 3, 'correct callcount');
-  assert.ok(getLicenseCallback.alwaysCalledWith({}), 'getLicense callback called with correct error');
+  assert.ok(getLicenseCallback.alwaysCalledWith({
+    cause: JSON.stringify({body: 'some-body'})
+  }), 'getLicense callback called with correct error');
 });
 
 QUnit.test('getLicense calls back with response body for non-400/500 status codes', function(assert) {


### PR DESCRIPTION
This adds a new `cause` property to the error object returned by `player.error()` when a license request fails with a 4xx or 5xx status code. It's a string representation, so, if it's JSON a consumer would need to call JSON.parse manually as we can't know whether it's JSON or not.

One way of using it is by listening to the error event and then re-setting the message to be the `cause`
```js
// notice the .one here, otherwise we'd get caught in an infinite loop
player.one('error', () => {
  var e = player.error();
  player.error(null);
  player.error({code: 5, message: e.cause})
});
```