### PR TITLE
fix: cast initData to Uint8Array

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -398,7 +398,7 @@ export const standard5July2016 = ({
   }
 
   const contentId = keySystemOptions.getContentId ?
-    keySystemOptions.getContentId(options, initData) : null;
+    keySystemOptions.getContentId(options, new Uint8Array(initData.buffer || initData)) : null;
 
   if (typeof video.mediaKeysObject === 'undefined') {
     // Prevent entering this path again.


### PR DESCRIPTION
In the legacy api, initData came back as a Uint8Array

By casting it, we minimize potential changes that users of contrib-eme have to make to update