### PR TITLE
fix: convert initData to a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ or
 You can control the license and certificate request processes by providing the following methods instead of the properties discussed above:
 
 * `getCertificate()` - Allows asynchronous retrieval of a certificate.
-* `getContentId()` - Allows synchronous retrieval of a content ID.
+* `getContentId()` - Allows synchronous retrieval of a content ID. It takes `emeOptions`, as well as the `initData` converted into a String.
 * `getLicense()` - Allows asynchronous retrieval of a license.
 
 ```js
@@ -149,7 +149,7 @@ You can control the license and certificate request processes by providing the f
         // if err, callback(err)
         // if success, callback(null, certificate)
       },
-      getContentId: function(emeOptions, initData) {
+      getContentId: function(emeOptions, contentId) {
         // return content ID
       },
       getLicense: function(emeOptions, contentId, keyMessage, callback) {

--- a/src/eme.js
+++ b/src/eme.js
@@ -1,7 +1,7 @@
 import videojs from 'video.js';
 import { requestPlayreadyLicense } from './playready';
 import window from 'global/window';
-import {mergeAndRemoveNull} from './utils';
+import {uint8ArrayToString, mergeAndRemoveNull} from './utils';
 import {httpResponseHandler} from './http-handler.js';
 import {
   defaultGetCertificate as defaultFairplayGetCertificate,
@@ -398,7 +398,7 @@ export const standard5July2016 = ({
   }
 
   const contentId = keySystemOptions.getContentId ?
-    keySystemOptions.getContentId(options, initData) : null;
+    keySystemOptions.getContentId(options, uint8ArrayToString(initData)) : null;
 
   if (typeof video.mediaKeysObject === 'undefined') {
     // Prevent entering this path again.

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -128,8 +128,8 @@ export const defaultGetCertificate = (fairplayOptions) => {
   };
 };
 
-export const defaultGetContentId = (emeOptions, contentId) => {
-  return getHostnameFromUri(contentId);
+export const defaultGetContentId = (emeOptions, initDataString) => {
+  return getHostnameFromUri(initDataString);
 };
 
 export const defaultGetLicense = (fairplayOptions) => {

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -7,7 +7,7 @@
  */
 import videojs from 'video.js';
 import window from 'global/window';
-import {stringToUint16Array, uint8ArrayToString, getHostnameFromUri, mergeAndRemoveNull} from './utils';
+import {stringToUint16Array, uint16ArrayToString, getHostnameFromUri, mergeAndRemoveNull} from './utils';
 import {httpResponseHandler} from './http-handler.js';
 
 export const FAIRPLAY_KEY_SYSTEM = 'com.apple.fps.1_0';
@@ -128,8 +128,8 @@ export const defaultGetCertificate = (fairplayOptions) => {
   };
 };
 
-export const defaultGetContentId = (emeOptions, initData) => {
-  return getHostnameFromUri(uint8ArrayToString(initData));
+export const defaultGetContentId = (emeOptions, contentId) => {
+  return getHostnameFromUri(contentId);
 };
 
 export const defaultGetLicense = (fairplayOptions) => {
@@ -174,7 +174,7 @@ const fairplay = ({video, initData, options, eventBus}) => {
       initData,
       getLicense,
       options,
-      contentId: getContentId(options, initData),
+      contentId: getContentId(options, uint16ArrayToString(initData)),
       eventBus
     });
   });

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,6 +17,10 @@ export const uint8ArrayToString = (array) => {
   return String.fromCharCode.apply(null, new Uint8Array(array.buffer || array));
 };
 
+export const uint16ArrayToString = (array) => {
+  return String.fromCharCode.apply(null, new Uint16Array(array.buffer || array));
+};
+
 export const getHostnameFromUri = (uri) => {
   const link = document.createElement('a');
 


### PR DESCRIPTION
This is to help get around the change in data type of initData between
the legacy API and the standards API.

In the legacy API, the initData was a Uint8Array but needed to be
converted to a Uint16Array to be able to toString it.

In the standards API, initData is an ArrayBuffer but can be converted to
a Uint8Array to be able to toString it.

We now do this string conversion for you so that you can just use the
contentId and not need to figure out whether legacy or standard API is
used.

BREAKING CHANGE: getContentId will now receive a string representation
of the initData