### PR TITLE
test: cleanup xhr correctly

### DIFF
--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -46,7 +46,14 @@ const resolveReject = (rejectVariable, rejectMessage) => {
   });
 };
 
-QUnit.module('videojs-contrib-eme eme');
+QUnit.module('videojs-contrib-eme eme', {
+  beforeEach() {
+    this.origXhr = videojs.xhr;
+  },
+  afterEach() {
+    videojs.xhr = this.origXhr;
+  }
+});
 
 QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key', function(assert) {
   const callCount = {total: 0, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}};

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -9,7 +9,18 @@ import videojs from 'video.js';
 import window from 'global/window';
 import { getMockEventBus } from './utils';
 
-QUnit.module('videojs-contrib-eme fairplay');
+QUnit.module('videojs-contrib-eme fairplay', {
+  beforeEach() {
+    this.origXhr = videojs.xhr;
+
+    videojs.xhr = (params, callback) => {
+      return callback(null, {statusCode: 200}, new Uint8Array([0, 1, 2, 3]).buffer);
+    };
+  },
+  afterEach() {
+    videojs.xhr = this.origXhr;
+  }
+});
 
 QUnit.test('lifecycle', function(assert) {
   assert.expect(23);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -362,6 +362,12 @@ QUnit.module('plugin guard functions', {
       }
     };
 
+    this.origXhr = videojs.xhr;
+
+    videojs.xhr = (params, callback) => {
+      return callback(null, {statusCode: 200}, new Uint8Array([0, 1, 2, 3]).buffer);
+    };
+
     this.initData1 = new Uint8Array([1, 2, 3]).buffer;
     this.initData2 = new Uint8Array([4, 5, 6]).buffer;
 
@@ -398,6 +404,7 @@ QUnit.module('plugin guard functions', {
   },
   afterEach() {
     window.navigator.requestMediaKeySystemAccess = this.origRequestMediaKeySystemAccess;
+    videojs.xhr = this.origXhr;
   }
 });
 


### PR DESCRIPTION
tests in `eme.test.js` mock `videojs.xhr` but never restore it. Fixing that causes tests in `fairplay.test.js` and `plugin.test.js` to fail as they rely on the mock xhr responding. This pull request cleans all that up.