### PR TITLE
add com.microsoft.playready.recommendation as a recognised key system

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -348,6 +348,7 @@ const standardizeKeySystemOptions = (keySystem, keySystemOptions) => {
   }
 
   const isFairplay = isFairplayKeySystem(keySystem);
+  const isPlayready = keySystem === 'com.microsoft.playready' || keySystem === 'com.microsoft.playready.recommendation';
 
   if (isFairplay && keySystemOptions.certificateUri && !keySystemOptions.getCertificate) {
     keySystemOptions.getCertificate = defaultFairplayGetCertificate(keySystemOptions);
@@ -362,7 +363,7 @@ const standardizeKeySystemOptions = (keySystem, keySystemOptions) => {
   }
 
   if (keySystemOptions.url && !keySystemOptions.getLicense) {
-    if (keySystem === 'com.microsoft.playready') {
+    if (isPlayready) {
       keySystemOptions.getLicense = defaultPlayreadyGetLicense(keySystemOptions);
     } else if (isFairplay) {
       keySystemOptions.getLicense = defaultFairplayGetLicense(keySystemOptions);


### PR DESCRIPTION
I've added `com.microsoft.playready.recommendation` as a recognised key system. The keysystems behave almost identically. Function [getSupportedKeySystem](https://github.com/videojs/videojs-contrib-eme/blob/main/src/eme.js#L74) is then dependant on the name of the key system so there shouldn't be any changes needed there.

I wanted to add a test that would check that both of the key systems to go through `defaultFairplayGetCertificate()`, but there is no test that check getCeritificate for any key system.