### PR TITLE
refactor: add support for future Video.js 8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   ],
   "dependencies": {
     "global": "^4.3.2",
-    "video.js": "^6 || ^7"
+    "video.js": "^6 || ^7 || ^8"
   },
   "devDependencies": {
     "conventional-changelog-cli": "^2.0.12",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -9,7 +9,7 @@ import {
   default as msPrefixed,
   PLAYREADY_KEY_SYSTEM
 } from './ms-prefixed';
-import { arrayBuffersEqual, arrayBufferFrom } from './utils';
+import { arrayBuffersEqual, arrayBufferFrom, merge } from './utils';
 import {version as VERSION} from '../package.json';
 
 export const hasSession = (sessions, initData) => {
@@ -156,7 +156,7 @@ export const handleMsNeedKeyEvent = (event, options, sessions, eventBus) => {
 };
 
 export const getOptions = (player) => {
-  return videojs.mergeOptions(player.currentSource(), player.eme.options);
+  return merge(player.currentSource(), player.eme.options);
 };
 
 /**
@@ -349,7 +349,7 @@ const eme = function(options = {}) {
     initializeMediaKeys(emeOptions = {}, callback = function() {}, suppressErrorIfPossible = false) {
       // TODO: this should be refactored and renamed to be less tied
       // to encrypted events
-      const mergedEmeOptions = videojs.mergeOptions(
+      const mergedEmeOptions = merge(
         player.currentSource(),
         options,
         emeOptions
@@ -406,9 +406,7 @@ const eme = function(options = {}) {
 };
 
 // Register the plugin with video.js.
-const registerPlugin = videojs.registerPlugin || videojs.plugin;
-
-registerPlugin('eme', eme);
+videojs.registerPlugin('eme', eme);
 
 // Include the version number.
 eme.VERSION = VERSION;

--- a/src/utils.js
+++ b/src/utils.js
@@ -58,8 +58,16 @@ export const arrayBufferFrom = (bufferOrTypedArray) => {
   return bufferOrTypedArray;
 };
 
+// Normalize between Video.js 6/7 (videojs.mergeOptions) and 8 (videojs.obj.merge).
+export const merge = (...args) => {
+  const context = videojs.obj || videojs;
+  const fn = context.merge || context.mergeOptions;
+
+  return fn.apply(context, args);
+};
+
 export const mergeAndRemoveNull = (...args) => {
-  const result = videojs.mergeOptions(...args);
+  const result = merge(...args);
 
   // Any header whose value is `null` will be removed.
   Object.keys(result).forEach(k => {


### PR DESCRIPTION
This library was using `videojs.mergeOptions` which will be deprecated in 8.0. This adds code to normalize between Video.js 6.x/7.x (using `videojs.mergeOptions`) and 8.x (using `videojs.obj.merge`).

Also, this removes the fallback on `videojs.plugin()` because that was replaced in either 5.x or 6.x with `videojs.registerPlugin()`. Either way, it wasn't needed.