### PR TITLE
fix: Close keySession when player is disposed

### DIFF
--- a/src/eme.js
+++ b/src/eme.js
@@ -108,7 +108,9 @@ export const makeNewRequest = (player, requestOptions) => {
 
   eventBus.trigger('keysessioncreated');
 
-  player.on('dispose', keySession.close);
+  player.on('dispose', () => {
+    keySession.close();
+  });
 
   return new Promise((resolve, reject) => {
     keySession.addEventListener('message', (event) => {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -49,7 +49,7 @@ export const removeSession = (sessions, initData) => {
   }
 };
 
-export const handleEncryptedEvent = (event, options, sessions, eventBus) => {
+export const handleEncryptedEvent = (player, event, options, sessions, eventBus) => {
   if (!options || !options.keySystems) {
     // return silently since it may be handled by a different system
     return Promise.resolve();
@@ -82,6 +82,7 @@ export const handleEncryptedEvent = (event, options, sessions, eventBus) => {
     sessions.push({ initData });
 
     return standard5July2016({
+      player,
       video: event.target,
       initDataType: event.initDataType,
       initData,
@@ -234,7 +235,7 @@ const onPlayerReady = (player, emeError) => {
       // https://github.com/videojs/video.js/pull/4780
       // videojs.log('eme', 'Received an \'encrypted\' event');
       setupSessions(player);
-      handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player.tech_)
+      handleEncryptedEvent(player, event, getOptions(player), player.eme.sessions, player.tech_)
         .catch(emeError);
     });
   } else if (window.WebKitMediaKeys) {
@@ -365,7 +366,7 @@ const eme = function(options = {}) {
       setupSessions(player);
 
       if (window.MediaKeys) {
-        handleEncryptedEvent(mockEncryptedEvent, mergedEmeOptions, player.eme.sessions, player.tech_)
+        handleEncryptedEvent(player, mockEncryptedEvent, mergedEmeOptions, player.eme.sessions, player.tech_)
           .then(() => callback())
           .catch((error) => {
             callback(error);

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -1,3 +1,5 @@
+import document from 'global/document';
+
 import QUnit from 'qunit';
 import videojs from 'video.js';
 import window from 'global/window';
@@ -48,6 +50,10 @@ const resolveReject = (rejectVariable, rejectMessage) => {
 
 QUnit.module('videojs-contrib-eme eme', {
   beforeEach() {
+    this.fixture = document.getElementById('qunit-fixture');
+    this.video = document.createElement('video');
+    this.fixture.appendChild(this.video);
+    this.player = videojs(this.video);
     this.origXhr = videojs.xhr;
   },
   afterEach() {
@@ -55,6 +61,7 @@ QUnit.module('videojs-contrib-eme eme', {
   }
 });
 
+// ALEX
 QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key', function(assert) {
   const callCount = {total: 0, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}};
   const initData = new Uint8Array([1, 2, 3]);
@@ -73,7 +80,7 @@ QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key'
     }
   };
 
-  makeNewRequest({
+  makeNewRequest(this.player, {
     mediaKeys: {
       createSession: () => mockSession
     },
@@ -197,7 +204,7 @@ QUnit.test('keystatuseschange with expired key closes and recreates session', fu
   };
   let creates = 0;
 
-  makeNewRequest({
+  makeNewRequest(this.player, {
     mediaKeys: {
       createSession: () => {
         creates++;
@@ -258,7 +265,7 @@ QUnit.test('keystatuseschange with internal-error logs a warning', function(asse
 
   videojs.log.warn = (...args) => warnCalls.push(args);
 
-  makeNewRequest({
+  makeNewRequest(this.player, {
     mediaKeys: {
       createSession: () => mockSession
     },
@@ -304,7 +311,7 @@ QUnit.test('accepts a license URL as an option', function(assert) {
   const done = assert.async();
   const origXhr = videojs.xhr;
   const xhrCalls = [];
-  const session = new videojs.EventTarget();
+  const mockSession = getMockSession();
 
   videojs.xhr = (options) => {
     xhrCalls.push(options);
@@ -314,12 +321,13 @@ QUnit.test('accepts a license URL as an option', function(assert) {
     keySystem: 'com.widevine.alpha',
     createMediaKeys: () => {
       return {
-        createSession: () => session
+        createSession: () => mockSession
       };
     }
   };
 
   standard5July2016({
+    player: this.player,
     keySystemAccess,
     video: {
       setMediaKeys: (createdMediaKeys) => Promise.resolve(createdMediaKeys)
@@ -335,7 +343,15 @@ QUnit.test('accepts a license URL as an option', function(assert) {
   }).catch((e) => {});
 
   setTimeout(() => {
-    session.trigger({
+    assert.equal(mockSession.listeners.length, 2, 'added listeners');
+    assert.equal(
+      mockSession.listeners[0].type,
+      'message',
+      'added message listener'
+    );
+
+    // Simulate 'message' event
+    mockSession.listeners[0].listener({
       type: 'message',
       message: 'the-message',
       messageType: 'license-request'
@@ -362,12 +378,12 @@ QUnit.test('accepts a license URL as property', function(assert) {
   const done = assert.async();
   const origXhr = videojs.xhr;
   const xhrCalls = [];
-  const session = new videojs.EventTarget();
+  const mockSession = getMockSession();
   const keySystemAccess = {
     keySystem: 'com.widevine.alpha',
     createMediaKeys: () => {
       return {
-        createSession: () => session
+        createSession: () => mockSession
       };
     }
   };
@@ -377,6 +393,7 @@ QUnit.test('accepts a license URL as property', function(assert) {
   };
 
   standard5July2016({
+    player: this.player,
     keySystemAccess,
     video: {
       setMediaKeys: (createdMediaKeys) => Promise.resolve(createdMediaKeys)
@@ -394,7 +411,15 @@ QUnit.test('accepts a license URL as property', function(assert) {
   }).catch((e) => {});
 
   setTimeout(() => {
-    session.trigger({
+    assert.equal(mockSession.listeners.length, 2, 'added listeners');
+    assert.equal(
+      mockSession.listeners[0].type,
+      'message',
+      'added message listener'
+    );
+
+    // Simulate 'message' event
+    mockSession.listeners[0].listener({
       type: 'message',
       message: 'the-message',
       messageType: 'license-request'
@@ -481,7 +506,8 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
         update: () => {
           callCounts.keySessionUpdate++;
           return Promise.resolve();
-        }
+        },
+        close: () => {}
       };
     }
   };
@@ -495,6 +521,7 @@ QUnit.test('5 July 2016 lifecycle', function(assert) {
   };
 
   standard5July2016({
+    player: this.player,
     video,
     initDataType: '',
     initData: '',
@@ -593,6 +620,7 @@ QUnit.test('errors when missing url/licenseUri or getLicense', function(assert) 
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video: {},
     keySystemAccess,
     options,
@@ -619,6 +647,7 @@ QUnit.test('errors when missing certificateUri and getCertificate for fairplay',
   const done = assert.async();
 
   standard5July2016({
+    player: this.player,
     video: {},
     keySystemAccess,
     options
@@ -650,6 +679,7 @@ QUnit.test('rejects promise when getCertificate throws error', function(assert) 
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video: {},
     keySystemAccess,
     options,
@@ -675,6 +705,7 @@ QUnit.test('rejects promise when createMediaKeys rejects', function(assert) {
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video: {},
     keySystemAccess,
     options,
@@ -704,6 +735,7 @@ QUnit.test('rejects promise when createMediaKeys rejects', function(assert) {
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video: {},
     keySystemAccess,
     options,
@@ -743,7 +775,8 @@ QUnit.test('rejects promise when addPendingSessions rejects', function(assert) {
             generateRequest: () => resolveReject(
               rejectGenerateRequest,
               'generateRequest failed'
-            )
+            ),
+            close: () => {}
           };
         }
       });
@@ -757,6 +790,7 @@ QUnit.test('rejects promise when addPendingSessions rejects', function(assert) {
   const test = (errMessage, testDescription) => {
     video.mediaKeysObject = undefined;
     standard5July2016({
+      player: this.player,
       video,
       keySystemAccess,
       options,
@@ -813,7 +847,8 @@ QUnit.test('getLicense not called for messageType that isnt license-request or l
               }
             },
             keyStatuses: [],
-            generateRequest: () => Promise.resolve()
+            generateRequest: () => Promise.resolve(),
+            close: () => {}
           };
         }
       });
@@ -824,6 +859,7 @@ QUnit.test('getLicense not called for messageType that isnt license-request or l
   };
 
   standard5July2016({
+    player: this.player,
     video,
     keySystemAccess,
     options,
@@ -855,7 +891,8 @@ QUnit.test('getLicense promise rejection', function(assert) {
               });
             },
             keyStatuses: [],
-            generateRequest: () => Promise.resolve()
+            generateRequest: () => Promise.resolve(),
+            close: () => {}
           };
         }
       });
@@ -867,6 +904,7 @@ QUnit.test('getLicense promise rejection', function(assert) {
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video,
     keySystemAccess,
     options,
@@ -968,7 +1006,8 @@ QUnit.test('keySession.update promise rejection', function(assert) {
             },
             keyStatuses: [],
             generateRequest: () => Promise.resolve(),
-            update: () => Promise.reject('keySession update failed')
+            update: () => Promise.reject('keySession update failed'),
+            close: () => {}
           };
         }
       });
@@ -980,6 +1019,7 @@ QUnit.test('keySession.update promise rejection', function(assert) {
   const done = assert.async(1);
 
   standard5July2016({
+    player: this.player,
     video,
     keySystemAccess,
     options,
@@ -995,7 +1035,7 @@ QUnit.test('emeHeaders option sets headers on default license xhr request', func
   const done = assert.async();
   const origXhr = videojs.xhr;
   const xhrCalls = [];
-  const session = new videojs.EventTarget();
+  const mockSession = getMockSession();
 
   videojs.xhr = (options) => {
     xhrCalls.push(options);
@@ -1005,12 +1045,13 @@ QUnit.test('emeHeaders option sets headers on default license xhr request', func
     keySystem: 'com.widevine.alpha',
     createMediaKeys: () => {
       return {
-        createSession: () => session
+        createSession: () => mockSession
       };
     }
   };
 
   standard5July2016({
+    player: this.player,
     keySystemAccess,
     video: {
       setMediaKeys: (createdMediaKeys) => Promise.resolve(createdMediaKeys)
@@ -1029,7 +1070,8 @@ QUnit.test('emeHeaders option sets headers on default license xhr request', func
   }).catch((e) => {});
 
   setTimeout(() => {
-    session.trigger({
+    // Simulate 'message' event
+    mockSession.listeners[0].listener({
       type: 'message',
       message: 'the-message',
       messageType: 'license-request'
@@ -1057,7 +1099,7 @@ QUnit.test('licenseHeaders keySystems property overrides emeHeaders value', func
   const done = assert.async();
   const origXhr = videojs.xhr;
   const xhrCalls = [];
-  const session = new videojs.EventTarget();
+  const mockSession = getMockSession();
 
   videojs.xhr = (options) => {
     xhrCalls.push(options);
@@ -1067,12 +1109,13 @@ QUnit.test('licenseHeaders keySystems property overrides emeHeaders value', func
     keySystem: 'com.widevine.alpha',
     createMediaKeys: () => {
       return {
-        createSession: () => session
+        createSession: () => mockSession
       };
     }
   };
 
   standard5July2016({
+    player: this.player,
     keySystemAccess,
     video: {
       setMediaKeys: (createdMediaKeys) => Promise.resolve(createdMediaKeys)
@@ -1096,7 +1139,8 @@ QUnit.test('licenseHeaders keySystems property overrides emeHeaders value', func
   }).catch((e) => {});
 
   setTimeout(() => {
-    session.trigger({
+    // Simulate 'message' event
+    mockSession.listeners[0].listener({
       type: 'message',
       message: 'the-message',
       messageType: 'license-request'
@@ -1139,7 +1183,14 @@ QUnit.test('sets required fairplay defaults if not explicitly configured', funct
   window.requestMediaKeySystemAccess = origRequestMediaKeySystemAccess;
 });
 
-QUnit.module('session management');
+QUnit.module('session management', {
+  beforeEach() {
+    this.fixture = document.getElementById('qunit-fixture');
+    this.video = document.createElement('video');
+    this.fixture.appendChild(this.video);
+    this.player = videojs(this.video);
+  }
+});
 
 QUnit.test('addSession saves options', function(assert) {
   const video = {
@@ -1228,12 +1279,14 @@ QUnit.test('addPendingSessions reuses saved options', function(assert) {
           return Promise.resolve();
         },
         // this call and everything after is beyond the scope of this test
-        update: () => Promise.resolve()
+        update: () => Promise.resolve(),
+        close: () => {}
       };
     }
   };
 
   return addPendingSessions({
+    player: this.player,
     video,
     createdMediaKeys
   }).then((resolve, reject) => {
@@ -1241,7 +1294,14 @@ QUnit.test('addPendingSessions reuses saved options', function(assert) {
   });
 });
 
-QUnit.module('videojs-contrib-eme getSupportedConfigurations');
+QUnit.module('videojs-contrib-eme getSupportedConfigurations', {
+  beforeEach() {
+    this.fixture = document.getElementById('qunit-fixture');
+    this.video = document.createElement('video');
+    this.fixture.appendChild(this.video);
+    this.player = videojs(this.video);
+  }
+});
 
 QUnit.test('includes audio and video content types', function(assert) {
   assert.deepEqual(
@@ -1352,7 +1412,7 @@ QUnit.test('makeNewRequest triggers keysessioncreated', function(assert) {
   const done = assert.async();
   const mockSession = getMockSession();
 
-  makeNewRequest({
+  makeNewRequest(this.player, {
     mediaKeys: {
       createSession: () => mockSession
     },

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -61,7 +61,6 @@ QUnit.module('videojs-contrib-eme eme', {
   }
 });
 
-// ALEX
 QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key', function(assert) {
   const callCount = {total: 0, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}};
   const initData = new Uint8Array([1, 2, 3]);

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -1182,6 +1182,44 @@ QUnit.test('sets required fairplay defaults if not explicitly configured', funct
   window.requestMediaKeySystemAccess = origRequestMediaKeySystemAccess;
 });
 
+QUnit.test('makeNewRequest triggers keysessioncreated', function(assert) {
+  const done = assert.async();
+  const mockSession = getMockSession();
+
+  makeNewRequest(this.player, {
+    mediaKeys: {
+      createSession: () => mockSession
+    },
+    eventBus: {
+      trigger: (eventName) => {
+        if (eventName === 'keysessioncreated') {
+          assert.ok(true, 'got a keysessioncreated event');
+          done();
+        }
+      }
+    }
+  });
+});
+
+QUnit.test('keySession is closed when player is disposed', function(assert) {
+  const mockSession = getMockSession();
+
+  makeNewRequest(this.player, {
+    mediaKeys: {
+      createSession: () => mockSession
+    },
+    eventBus: {
+      trigger: (eventName) => {}
+    }
+  });
+
+  assert.equal(mockSession.numCloses, 0, 'no close() calls initially');
+
+  this.player.dispose();
+
+  assert.equal(mockSession.numCloses, 1, 'close() called once after dipose');
+});
+
 QUnit.module('session management', {
   beforeEach() {
     this.fixture = document.getElementById('qunit-fixture');
@@ -1405,23 +1443,4 @@ QUnit.test('uses supportedConfigurations directly if provided', function(assert)
     }],
     'used supportedConfigurations directly'
   );
-});
-
-QUnit.test('makeNewRequest triggers keysessioncreated', function(assert) {
-  const done = assert.async();
-  const mockSession = getMockSession();
-
-  makeNewRequest(this.player, {
-    mediaKeys: {
-      createSession: () => mockSession
-    },
-    eventBus: {
-      trigger: (eventName) => {
-        if (eventName === 'keysessioncreated') {
-          assert.ok(true, 'got a keysessioncreated event');
-          done();
-        }
-      }
-    }
-  });
 });

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -356,6 +356,10 @@ QUnit.test('only registers for spec-compliant events even if legacy APIs are ava
 
 QUnit.module('plugin guard functions', {
   beforeEach() {
+    this.fixture = document.getElementById('qunit-fixture');
+    this.video = document.createElement('video');
+    this.fixture.appendChild(this.video);
+    this.player = videojs(this.video);
     this.options = {
       keySystems: {
         'org.w3.clearkey': {url: 'some-url'}
@@ -412,7 +416,7 @@ QUnit.test('handleEncryptedEvent checks for required options', function(assert) 
   const done = assert.async();
   const sessions = [];
 
-  handleEncryptedEvent(this.event1, {}, sessions).then(() => {
+  handleEncryptedEvent(this.player, this.event1, {}, sessions).then(() => {
     assert.equal(sessions.length, 0, 'did not create a session when no options');
     done();
   });
@@ -422,7 +426,7 @@ QUnit.test('handleEncryptedEvent checks for required init data', function(assert
   const done = assert.async();
   const sessions = [];
 
-  handleEncryptedEvent({ target: {}, initData: null }, this.options, sessions).then(() => {
+  handleEncryptedEvent(this.player, { target: {}, initData: null }, this.options, sessions).then(() => {
     assert.equal(sessions.length, 0, 'did not create a session when no init data');
     done();
   });
@@ -433,7 +437,7 @@ QUnit.test('handleEncryptedEvent creates session', function(assert) {
   const sessions = [];
 
   // testing the rejection path because this isn't a real session
-  handleEncryptedEvent(this.event1, this.options, sessions).catch(() => {
+  handleEncryptedEvent(this.player, this.event1, this.options, sessions).catch(() => {
     assert.equal(sessions.length, 1, 'created a session when keySystems in options');
     assert.equal(sessions[0].initData, this.initData1, 'captured initData in the session');
     done();
@@ -445,8 +449,8 @@ QUnit.test('handleEncryptedEvent creates new session for new init data', functio
   const sessions = [];
 
   // testing the rejection path because this isn't a real session
-  handleEncryptedEvent(this.event1, this.options, sessions).catch(() => {
-    return handleEncryptedEvent(this.event2, this.options, sessions).catch(() => {
+  handleEncryptedEvent(this.player, this.event1, this.options, sessions).catch(() => {
+    return handleEncryptedEvent(this.player, this.event2, this.options, sessions).catch(() => {
       assert.equal(sessions.length, 2, 'created a new session when new init data');
       assert.equal(sessions[0].initData, this.initData1, 'retained session init data');
       assert.equal(sessions[1].initData, this.initData2, 'added new session init data');
@@ -460,9 +464,9 @@ QUnit.test('handleEncryptedEvent doesn\'t create duplicate sessions', function(a
   const sessions = [];
 
   // testing the rejection path because this isn't a real session
-  handleEncryptedEvent(this.event1, this.options, sessions).catch(() => {
-    return handleEncryptedEvent(this.event2, this.options, sessions).catch(() => {
-      return handleEncryptedEvent(this.event2, this.options, sessions).then(() => {
+  handleEncryptedEvent(this.player, this.event1, this.options, sessions).catch(() => {
+    return handleEncryptedEvent(this.player, this.event2, this.options, sessions).catch(() => {
+      return handleEncryptedEvent(this.player, this.event2, this.options, sessions).then(() => {
         assert.equal(sessions.length, 2, 'no new session when same init data');
         assert.equal(sessions[0].initData, this.initData1, 'retained session init data');
         assert.equal(sessions[1].initData, this.initData2, 'retained session init data');
@@ -484,7 +488,7 @@ QUnit.test('handleEncryptedEvent uses predefined init data', function(assert) {
   const sessions = [];
 
   // testing the rejection path because this isn't a real session
-  handleEncryptedEvent(this.event2, options, sessions).catch(() => {
+  handleEncryptedEvent(this.player, this.event2, options, sessions).catch(() => {
     assert.equal(sessions.length, 1, 'created a session when keySystems in options');
     assert.deepEqual(sessions[0].initData, this.initData1, 'captured initData in the session');
     done();


### PR DESCRIPTION
## Description
This fixes a bug where a `keySession` could continue to receive events and trigger license requests even after a player is disposed.

## Specific Additions
Call `keySession.close()` on `'dipose'`. 

Relevant spec: https://www.w3.org/TR/encrypted-media/#x6.-mediakeysession-interface
> A [MediaKeySession](https://www.w3.org/TR/encrypted-media/#dom-mediakeysession) object shall not be destroyed and shall continue to receive events if it is not [closed](https://www.w3.org/TR/encrypted-media/#media-key-session-closed) and the [MediaKeys](https://www.w3.org/TR/encrypted-media/#dom-mediakeys) object that created it remains accessible. Otherwise, a [MediaKeySession](https://www.w3.org/TR/encrypted-media/#dom-mediakeysession) object that is no longer accessible shall not receive further events and may be destroyed.

`close()`: https://www.w3.org/TR/encrypted-media/#dom-mediakeysession-close