### PR TITLE
fix: missing player argument

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -288,7 +288,7 @@ const onPlayerReady = (player, emeError) => {
       // https://github.com/videojs/video.js/pull/4780
       // videojs.log('eme', 'Received an \'encrypted\' event');
       setupSessions(player);
-      handleEncryptedEvent(event, getOptions(player), player.eme.sessions, player.tech_)
+      handleEncryptedEvent(player, event, getOptions(player), player.eme.sessions, player.tech_)
         .catch(emeError);
     });
 


### PR DESCRIPTION
## Description
When [cherry-picking commits](https://github.com/videojs/videojs-contrib-eme/pull/183) into the `3.x` branch, a mistake was made while resolving merge conflicts- the `player` was not passed to the `handleEncryptedEvent()` function. This addresses that.