### PR TITLE
fix: playready message passthrough (#201)

### DIFF
--- a/src/playready.js
+++ b/src/playready.js
@@ -17,7 +17,7 @@ export const getMessageContents = (message) => {
   const xml = (new window.DOMParser())
     .parseFromString(xmlString, 'application/xml');
   const headersElement = xml.getElementsByTagName('HttpHeaders')[0];
-  const headers = {};
+  let headers = {};
 
   if (headersElement) {
     const headerNames = headersElement.getElementsByTagName('name');
@@ -34,6 +34,16 @@ export const getMessageContents = (message) => {
 
   if (challengeElement) {
     challenge = window.atob(challengeElement.childNodes[0].nodeValue);
+  }
+
+  // If we failed to parse the xml the soap message might be encoded already.
+  // set the message data as the challenge and add generic SOAP headers.
+  if (xml.querySelector('parsererror')) {
+    headers = {
+      'Content-Type': 'text/xml; charset=utf-8',
+      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+    };
+    challenge = message;
   }
 
   return {

--- a/test/playready-message.js
+++ b/test/playready-message.js
@@ -56,3 +56,36 @@ export const createMessageBuffer = (headers) => {
       </LicenseAcquisition>
     </PlayReadyKeyMessage>`);
 };
+
+export const unwrappedPlayreadyMessage = `
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <AcquireLicense xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols">
+      <challenge>
+        <Challenge xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols/messages">
+          <LA xmlns="http://schemas.microsoft.com/DRM/2007/03/protocols" Id="SignedData" xml:space="preserve"><Version>1</Version><ContentHeader><WRMHEADER xmlns="http://schemas.microsoft.com/DRM/2007/03/PlayReadyHeader" version="4.0.0.0"><DATA><PROTECTINFO><KEYLEN>16</KEYLEN><ALGID>AESCTR</ALGID></PROTECTINFO><KID>U24lieXb6USvujjSyhfRdg==</KID><CHECKSUM>TKWDEqady2g=</CHECKSUM><LA_URL>https://foo.bar.license</LA_URL></DATA></WRMHEADER></ContentHeader><CLIENTINFO><CLIENTVERSION>4.2.0.5545</CLIENTVERSION></CLIENTINFO><RevocationLists><RevListInfo><ListID>ioydTlK2p0WXkWklprR5Hw==</ListID><Version>13</Version></RevListInfo><RevListInfo><ListID>Ef/RUojT3U6Ct2jqTCChbA==</ListID><Version>68</Version></RevListInfo></RevocationLists><LicenseNonce>U9WysleTindM/gVQyExDdw==</LicenseNonce><ClientTime>1706149441</ClientTime> <EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#" Type="http://www.w3.org/2001/04/xmlenc#Element"><EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"></EncryptionMethod><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><EncryptedKey xmlns="http://www.w3.org/2001/04/xmlenc#"><EncryptionMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecc256"></EncryptionMethod><KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><KeyName>WMRMServer</KeyName></KeyInfo><CipherData><CipherValue>barfoobarfoo</CipherValue></CipherData></EncryptedKey></KeyInfo><CipherData><CipherValue>foocipherbarcipher</CipherValue></CipherData></EncryptedData></LA>
+          <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <SignedInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+              <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"></CanonicalizationMethod>
+              <SignatureMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#ecdsa-sha256"></SignatureMethod>
+              <Reference URI="#SignedData">
+                <DigestMethod Algorithm="http://schemas.microsoft.com/DRM/2007/03/protocols#sha256"></DigestMethod>
+                <DigestValue>FL7P8/ITc+xFvUeoyMRq2JnNbJuhhKINsXtdDuM1Y78=</DigestValue>
+              </Reference>
+            </SignedInfo>
+            <SignatureValue>Ocy3UTUu52QI0MIzdftANLQgJM3SsP6E2XvPlKYzQBtvscJbm/uTi38zrfY2RBU3FJZLtcj0O72lb5Mq5/CNJA==</SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+              <KeyValue>
+                <ECCKeyValue>
+                  <PublicKey>nxbw6pwjF4fF5sEqM23KU54ifXrRvejWK5GVdjdzCMY3dvjdp7Ho5h5YiZ34xOSAUHJsZwa4DW+P6XFIDauDzg==</PublicKey>
+                </ECCKeyValue>
+              </KeyValue>
+            </KeyInfo>
+          </Signature>
+        </Challenge>
+      </challenge>
+    </AcquireLicense>
+  </soap:Body>
+</soap:Envelope>
+`;

--- a/test/playready.test.js
+++ b/test/playready.test.js
@@ -5,7 +5,8 @@ import {
 } from '../src/playready';
 import {
   createMessageBuffer,
-  challengeElement
+  challengeElement,
+  unwrappedPlayreadyMessage
 } from './playready-message';
 import videojs from 'video.js';
 
@@ -23,6 +24,22 @@ QUnit.test('getMessageContents parses message contents', function(assert) {
     'parses headers'
   );
   assert.deepEqual(message, challengeElement, 'parses challenge element');
+});
+
+QUnit.test('getMessageContents parses utf-8 contents', function(assert) {
+  const encoder = new TextEncoder();
+  const encodedMessageData = encoder.encode(unwrappedPlayreadyMessage);
+  const {headers, message} = getMessageContents(encodedMessageData);
+
+  assert.deepEqual(
+    headers,
+    {
+      'Content-Type': 'text/xml; charset=utf-8',
+      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+    },
+    'parses headers'
+  );
+  assert.deepEqual(message, encodedMessageData, 'parses challenge element');
 });
 
 QUnit.test('emeHeaders sent with license requests', function(assert) {


### PR DESCRIPTION
See: https://github.com/videojs/videojs-contrib-eme/pull/201
same fix for the 3.x branch.