### PR TITLE
fix: disable firefox headless in karma

### DIFF
--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -10,6 +10,14 @@ module.exports = function(config) {
       delete defaults.bsEdgeWin10;
       delete defaults.bsIE11Win10;
       return defaults;
+    },
+    browsers(aboutToRun) {
+      // TODO - current firefox headless fails to run w karma, blocking the npm version script.
+      // We should look into a better workaround that allows us to still run firefox through karma
+      // See https://github.com/karma-runner/karma-firefox-launcher/issues/328
+      return aboutToRun.filter(function(launcherName) {
+        return launcherName !== 'FirefoxHeadless';
+      });
     }
   };
 


### PR DESCRIPTION
We need to disable the karma launcher from running firefox headless as the karma launcher is still broken on updated macs. See: https://github.com/karma-runner/karma-firefox-launcher/issues/328