### PR TITLE
Get latest player options when handling encrypted and msneedkey events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "global": "^4.3.2",
-        "video.js": "^6 || ^7"
+        "video.js": "^6 || ^7 || ^8"
       },
       "devDependencies": {
         "conventional-changelog-cli": "^2.0.12",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -239,7 +239,7 @@ const onPlayerReady = (player, emeError) => {
     player.tech_.el_.addEventListener('encrypted', (event) => {
       videojs.log.debug('eme', 'Received an \'encrypted\' event');
       setupSessions(player);
-      handleEncryptedEvent(player, event, playerOptions, player.eme.sessions, player.tech_)
+      handleEncryptedEvent(player, event, getOptions(player), player.eme.sessions, player.tech_)
         .catch(emeError);
     });
   } else if (window.WebKitMediaKeys) {
@@ -254,7 +254,7 @@ const onPlayerReady = (player, emeError) => {
       videojs.log.debug('eme', 'Received an \'msneedkey\' event');
       setupSessions(player);
       try {
-        handleMsNeedKeyEvent(event, playerOptions, player.eme.sessions, player.tech_);
+        handleMsNeedKeyEvent(event, getOptions(player), player.eme.sessions, player.tech_);
       } catch (error) {
         emeError(error);
       }


### PR DESCRIPTION
I noticed an error as we tried to update to v5.1.0. We were unable to get media keys because the player options had changed between being set at the start of `onPlayerReady` and when they were used in handling the `encrypted` event.