### PR TITLE
fix: getOptions after encrypted event

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -228,15 +228,19 @@ const onPlayerReady = (player, emeError) => {
 
   setupSessions(player);
 
-  const playerOptions = getOptions(player);
-  // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
-  // If we are using this keysystem we want to use WebkitMediaKeys.
-  const isLegacyFairplay = playerOptions.keySystem && playerOptions.keySystem[LEGACY_FAIRPLAY_KEY_SYSTEM];
-
-  if (window.MediaKeys && !isLegacyFairplay) {
+  if (window.MediaKeys) {
     // Support EME 05 July 2016
     // Chrome 42+, Firefox 47+, Edge, Safari 12.1+ on macOS 10.14+
     player.tech_.el_.addEventListener('encrypted', (event) => {
+      const playerOptions = getOptions(player);
+      // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
+      // If we are using this keysystem we want to use WebkitMediaKeys.
+      // This can be initialized manually with initLegacyFairplay().
+      const isLegacyFairplay = playerOptions.keySystems && playerOptions.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM];
+
+      if (isLegacyFairplay) {
+        return;
+      }
       videojs.log.debug('eme', 'Received an \'encrypted\' event');
       setupSessions(player);
       handleEncryptedEvent(player, event, getOptions(player), player.eme.sessions, player.tech_)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -55,6 +55,13 @@ export const handleEncryptedEvent = (player, event, options, sessions, eventBus)
     // return silently since it may be handled by a different system
     return Promise.resolve();
   }
+  // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
+  // If we are using this keysystem we want to use WebkitMediaKeys.
+  // This can be initialized manually with initLegacyFairplay().
+  if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM]) {
+    videojs.log.debug('eme', `Ignoring \'encrypted\' event, using legacy fairplay keySystem ${LEGACY_FAIRPLAY_KEY_SYSTEM}`);
+    return Promise.resolve();
+  }
 
   let initData = event.initData;
 
@@ -232,16 +239,6 @@ const onPlayerReady = (player, emeError) => {
     // Support EME 05 July 2016
     // Chrome 42+, Firefox 47+, Edge, Safari 12.1+ on macOS 10.14+
     player.tech_.el_.addEventListener('encrypted', (event) => {
-      const playerOptions = getOptions(player);
-      // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
-      // If we are using this keysystem we want to use WebkitMediaKeys.
-      // This can be initialized manually with initLegacyFairplay().
-      const isLegacyFairplay = playerOptions.keySystems && playerOptions.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM];
-
-      if (isLegacyFairplay) {
-        videojs.log.debug('eme', `Ignoring \'encrypted\' event, using legacy fairplay keySystem ${LEGACY_FAIRPLAY_KEY_SYSTEM}`);
-        return;
-      }
       videojs.log.debug('eme', 'Received an \'encrypted\' event');
       setupSessions(player);
       handleEncryptedEvent(player, event, getOptions(player), player.eme.sessions, player.tech_)

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -239,6 +239,7 @@ const onPlayerReady = (player, emeError) => {
       const isLegacyFairplay = playerOptions.keySystems && playerOptions.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM];
 
       if (isLegacyFairplay) {
+        videojs.log.debug('eme', `Ignoring \'encrypted\' event, using legacy fairplay keySystem ${LEGACY_FAIRPLAY_KEY_SYSTEM}`);
         return;
       }
       videojs.log.debug('eme', 'Received an \'encrypted\' event');

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -356,20 +356,19 @@ const eme = function(options = {}) {
       }
     },
     initLegacyFairplay() {
-      const playerOptions = getOptions(player);
       const handleFn = (event) => {
         videojs.log.debug('eme', 'Received a \'webkitneedkey\' event');
         // TODO it's possible that the video state must be cleared if reusing the same video
         // element between sources
         setupSessions(player);
-        handleWebKitNeedKeyEvent(event, playerOptions, player.tech_)
+        handleWebKitNeedKeyEvent(event, getOptions(player), player.tech_)
           .catch(emeError);
       };
 
       // Support Safari EME with FairPlay
       // (also used in early Chrome or Chrome with EME disabled flag)
       player.tech_.el_.addEventListener('webkitneedkey', (event) => {
-        const firstWebkitneedkeyTimeout = playerOptions.firstWebkitneedkeyTimeout || 1000;
+        const firstWebkitneedkeyTimeout = getOptions(player).firstWebkitneedkeyTimeout || 1000;
         const src = player.src();
         // on source change or first startup reset webkitneedkey options.
 

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -430,6 +430,21 @@ QUnit.test('handleEncryptedEvent checks for required options', function(assert) 
   });
 });
 
+QUnit.test('handleEncryptedEvent checks for legacy fairplay', function(assert) {
+  const done = assert.async();
+  const sessions = [];
+  const options = {
+    keySystems: {
+      'com.apple.fps.1_0': {url: 'some-url'}
+    }
+  };
+
+  handleEncryptedEvent(this.player, this.event1, options, sessions).then(() => {
+    assert.equal(sessions.length, 0, 'did not create a session when no options');
+    done();
+  });
+});
+
 QUnit.test('handleEncryptedEvent checks for required init data', function(assert) {
   const done = assert.async();
   const sessions = [];


### PR DESCRIPTION
Fixes an issue where the player options might not be set by the time the 'encrypted' event listener is attached, which can erroneously follow the `MediaKeys` flow instead of `WebkitMediaKeys` when legacy fairplay is keysystem. Also adds some debug logging to better track this behavior.

...and no, surprisingly the original typo was _not_ the actual problem. 😄  