### PR TITLE
feat: event payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,8 +617,10 @@ This event is triggered directly from the underlying `keystatuseschange` event, 
 When the key session is created, an event of type `keysessioncreated` will be triggered on the Video.js playback tech.
 
 ```
-player.tech().on('keysessioncreated', function(event) {
-  // note that there is no event data for keysessioncreated
+player.tech().on('keysessioncreated', function(keySession) {
+  // Event data:
+  // keySession: the mediaKeySession object 
+  // https://www.w3.org/TR/encrypted-media/#mediakeysession-interface
 });
 ```
 

--- a/src/fairplay.js
+++ b/src/fairplay.js
@@ -84,11 +84,18 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
       return;
     }
 
-    eventBus.trigger('keysessioncreated');
+    eventBus.trigger({
+      type: 'keysessioncreated',
+      keySession
+    });
 
     keySession.contentId = contentId;
 
     keySession.addEventListener('webkitkeymessage', (event) => {
+      eventBus.trigger({
+        type: 'keymessage',
+        messageEvent: event
+      });
       getLicense(options, contentId, event.message, (err, license) => {
         if (eventBus) {
           eventBus.trigger('licenserequestattempted');
@@ -105,6 +112,11 @@ const addKey = ({video, contentId, initData, cert, options, getLicense, eventBus
         }
 
         keySession.update(new Uint8Array(license));
+
+        eventBus.trigger({
+          type: 'keysessionupdated',
+          keySession
+        });
       });
     });
 

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -9,6 +9,7 @@
 import window from 'global/window';
 import { requestPlayreadyLicense } from './playready';
 import videojs from 'video.js';
+import { getMediaKeySystemConfigurations } from './utils';
 
 export const PLAYREADY_KEY_SYSTEM = 'com.microsoft.playready';
 
@@ -20,7 +21,7 @@ export const addKeyToSession = (options, session, event, eventBus, emeError) => 
       if (err) {
         const metadata = {
           errorType: videojs.Error.EMEFailedToRequestMediaKeySystemAccess,
-          keySystem: PLAYREADY_KEY_SYSTEM
+          config: getMediaKeySystemConfigurations(options.keySystems)
         };
 
         emeError(err, metadata);

--- a/src/ms-prefixed.js
+++ b/src/ms-prefixed.js
@@ -33,6 +33,11 @@ export const addKeyToSession = (options, session, event, eventBus, emeError) => 
       }
 
       session.update(key);
+
+      eventBus.trigger({
+        type: 'keysessionupdated',
+        keySession: session
+      });
     });
     return;
   }
@@ -92,7 +97,10 @@ export const createSession = (video, initData, options, eventBus, emeError) => {
     throw error;
   }
 
-  eventBus.trigger('keysessioncreated');
+  eventBus.trigger({
+    type: 'keysessioncreated',
+    keySession: session
+  });
 
   // Note that mskeymessage may not always be called for PlayReady:
   //
@@ -104,6 +112,10 @@ export const createSession = (video, initData, options, eventBus, emeError) => {
   // eslint-disable-next-line max-len
   // @see [PlayReady License Acquisition]{@link https://msdn.microsoft.com/en-us/library/dn468979.aspx}
   session.addEventListener('mskeymessage', (event) => {
+    eventBus.trigger({
+      type: 'keymessage',
+      messageEvent: event
+    });
     addKeyToSession(options, session, event, eventBus, emeError);
   });
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -10,7 +10,7 @@ import {
   PLAYREADY_KEY_SYSTEM
 } from './ms-prefixed';
 import {detectSupportedCDMs } from './cdm.js';
-import { arrayBuffersEqual, arrayBufferFrom, merge } from './utils';
+import { arrayBuffersEqual, arrayBufferFrom, merge, getMediaKeySystemConfigurations } from './utils';
 import {version as VERSION} from '../package.json';
 
 export const hasSession = (sessions, initData) => {
@@ -103,7 +103,7 @@ export const handleEncryptedEvent = (player, event, options, sessions, eventBus,
   }).catch((error) => {
     const metadata = {
       errorType: videojs.Error.EMEFailedToRequestMediaKeySystemAccess,
-      config: options.keySystems
+      config: getMediaKeySystemConfigurations(options.keySystems)
     };
 
     emeError(error, metadata);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 import document from 'global/document';
 import videojs from 'video.js';
+import { getSupportedConfigurations } from './eme';
 
 export const stringToUint16Array = (string) => {
   // 2 bytes for each char
@@ -77,4 +78,21 @@ export const mergeAndRemoveNull = (...args) => {
   });
 
   return result;
+};
+
+/**
+ * Transforms the keySystems object into a MediaKeySystemConfiguration Object array.
+ *
+ * @param {Object} keySystems object from the options.
+ * @return {Array} of MediaKeySystemConfiguration objects.
+ */
+export const getMediaKeySystemConfigurations = (keySystems) => {
+  const config = [];
+
+  Object.keys(keySystems).forEach((keySystem) => {
+    const mediaKeySystemConfig = getSupportedConfigurations(keySystem, keySystems[keySystem])[0];
+
+    config.push(mediaKeySystemConfig);
+  });
+  return config;
 };

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -91,7 +91,8 @@ QUnit.test('keystatuseschange triggers keystatuschange on eventBus for each key'
     options: {},
     getLicense() {},
     removeSession() {},
-    eventBus
+    eventBus,
+    emeError() {}
   });
 
   assert.equal(mockSession.listeners.length, 2, 'added listeners');

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -336,13 +336,14 @@ QUnit.test('keysessioncreated fired on key session created', function(assert) {
   const done = assert.async();
   const initData = new Uint8Array([1, 2, 3, 4]).buffer;
   let sessionCreated = false;
+  const addEventListener = () => {};
   const video = {
     webkitSetMediaKeys: () => {
       video.webkitKeys = {
         createSession: () => {
           sessionCreated = true;
           return {
-            addEventListener: () => {}
+            addEventListener
           };
         }
       };
@@ -350,8 +351,9 @@ QUnit.test('keysessioncreated fired on key session created', function(assert) {
   };
   const eventBus = {
     trigger: (event) => {
-      if (event === 'keysessioncreated') {
+      if (event.type === 'keysessioncreated') {
         assert.ok(sessionCreated, 'keysessioncreated fired after session created');
+        assert.deepEqual(event.keySession, { addEventListener }, 'keySession payload passed with event');
         done();
       }
     }

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -178,7 +178,7 @@ QUnit.test('calls getKey when provided on key message', function(assert) {
   };
   const emeError = (_, metadata) => {
     assert.equal(metadata.errorType, videojs.Error.EMEFailedToRequestMediaKeySystemAccess, 'errorType is expected value');
-    assert.equal(metadata.keySystem, PLAYREADY_KEY_SYSTEM, 'keySystem is expected value');
+    assert.deepEqual(metadata.config, [{}], 'keySystem is expected value');
   };
 
   msPrefixed({

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -595,11 +595,12 @@ QUnit.test('will use a custom getLicense method if one is provided', function(as
 });
 
 QUnit.test('createSession triggers keysessioncreated', function(assert) {
+  const addEventListener = () => {};
   const video = {
     msKeys: {
       createSession: () => {
         return {
-          addEventListener: () => {}
+          addEventListener
         };
       }
     }
@@ -610,8 +611,9 @@ QUnit.test('createSession triggers keysessioncreated', function(assert) {
 
   assert.equal(eventBus.calls.length, 1, 'one event triggered');
   assert.equal(
-    eventBus.calls[0],
+    eventBus.calls[0].type,
     'keysessioncreated',
     'triggered keysessioncreated event'
   );
+  assert.deepEqual(eventBus.calls[0].keySession, { addEventListener }, 'keysessioncreated payload');
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,7 +3,8 @@ import QUnit from 'qunit';
 import {
   arrayBuffersEqual,
   arrayBufferFrom,
-  mergeAndRemoveNull
+  mergeAndRemoveNull,
+  getMediaKeySystemConfigurations
 } from '../src/utils';
 
 QUnit.module('utils');
@@ -71,4 +72,32 @@ QUnit.test('mergeAndRemoveNull removes property if value is null', function(asse
     a: 'A',
     c: 'c'
   }, 'successfully merged and removed null property');
+});
+
+QUnit.test('getMediaKeySystemConfigurations returns MediaKeySystemConfiguration array', function(assert) {
+  const config = getMediaKeySystemConfigurations({
+    'com.widevine.alpha': {
+      audioContentType: 'audio/mp4; codecs="mp4a.40.2"',
+      audioRobustness: 'SW_SECURE_CRYPTO',
+      videoContentType: 'video/mp4; codecs="avc1.42E01E"',
+      videoRobustness: 'SW_SECURE_CRYPTO'
+    }
+  });
+
+  const expectedConfig = [{
+    audioCapabilities: [
+      {
+        contentType: 'audio/mp4; codecs=\"mp4a.40.2\"',
+        robustness: 'SW_SECURE_CRYPTO'
+      }
+    ],
+    videoCapabilities: [
+      {
+        contentType: 'video/mp4; codecs=\"avc1.42E01E\"',
+        robustness: 'SW_SECURE_CRYPTO'
+      }
+    ]
+  }];
+
+  assert.deepEqual(config, expectedConfig, 'getMediaKeysystemConfigurations returns expected values');
 });


### PR DESCRIPTION
Adding event payloads to most new events and fix tests. Also emit a new event `'keystatuseschanged'`, when the event of the same name is emitted from the `keySession` object, which will pass the entire keyStatusMap as a payload.