### PR TITLE
fix: headers should be case-insensitive

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -68,13 +68,26 @@ export const merge = (...args) => {
 };
 
 export const mergeAndRemoveNull = (...args) => {
-  const result = merge(...args);
+  const result = {};
 
-  // Any header whose value is `null` will be removed.
-  Object.keys(result).forEach(k => {
-    if (result[k] === null) {
-      delete result[k];
+  args.forEach((headers) => {
+    if (!headers) {
+      return;
     }
+
+    Object.keys(headers).forEach((header) => {
+      const value = headers[header];
+
+      // Lowercase the header name to be consistent.
+      header = header.toLowerCase();
+
+      if (value !== null) {
+        result[header] = value;
+      } else {
+        // Any header whose value is `null` will be removed.
+        delete result[header];
+      }
+    });
   });
 
   return result;

--- a/test/eme.test.js
+++ b/test/eme.test.js
@@ -377,7 +377,7 @@ QUnit.test('accepts a license URL as an option', function(assert) {
       requestType: 'license',
       body: 'the-message',
       headers: {
-        'Content-type': 'application/octet-stream'
+        'content-type': 'application/octet-stream'
       }
     }, 'made request with proper options');
 
@@ -453,7 +453,7 @@ QUnit.test('accepts a license URL as property', function(assert) {
       requestType: 'license',
       body: 'the-message',
       headers: {
-        'Content-type': 'application/octet-stream'
+        'content-type': 'application/octet-stream'
       }
     }, 'made request with proper options');
 
@@ -1148,7 +1148,7 @@ QUnit.test('emeHeaders option sets headers on default license xhr request', func
         'com.widevine.alpha': 'some-url'
       },
       emeHeaders: {
-        'Some-Header': 'some-header-value'
+        'some-header': 'some-header-value'
       }
     },
     eventBus: mockEventBus
@@ -1170,8 +1170,8 @@ QUnit.test('emeHeaders option sets headers on default license xhr request', func
       requestType: 'license',
       body: 'the-message',
       headers: {
-        'Content-type': 'application/octet-stream',
-        'Some-Header': 'some-header-value'
+        'content-type': 'application/octet-stream',
+        'some-header': 'some-header-value'
       }
     }, 'made request with proper emeHeaders option value');
 
@@ -1249,8 +1249,8 @@ QUnit.test('licenseHeaders keySystems property overrides emeHeaders value', func
       requestType: 'license',
       body: 'the-message',
       headers: {
-        'Content-type': 'application/octet-stream',
-        'Some-Header': 'priority-header-value'
+        'content-type': 'application/octet-stream',
+        'some-header': 'priority-header-value'
       }
     }, 'made request with proper licenseHeaders value');
 

--- a/test/fairplay.test.js
+++ b/test/fairplay.test.js
@@ -457,8 +457,8 @@ QUnit.test('emeHeaders sent with license and certificate requests', function(ass
     requestType: 'license',
     body: undefined,
     headers: {
-      'Content-type': 'application/octet-stream',
-      'Some-Header': 'some-header-value'
+      'content-type': 'application/octet-stream',
+      'some-header': 'some-header-value'
     }
   }, 'made license request with proper emeHeaders value');
 
@@ -467,7 +467,7 @@ QUnit.test('emeHeaders sent with license and certificate requests', function(ass
     responseType: 'arraybuffer',
     requestType: 'license',
     headers: {
-      'Some-Header': 'some-header-value'
+      'some-header': 'some-header-value'
     }
   }, 'made certificate request with proper emeHeaders value');
 
@@ -512,8 +512,8 @@ QUnit.test('licenseHeaders and certificateHeaders properties override emeHeaders
     requestType: 'license',
     body: undefined,
     headers: {
-      'Content-type': 'application/octet-stream',
-      'Some-Header': 'higher-priority-license-header'
+      'content-type': 'application/octet-stream',
+      'some-header': 'higher-priority-license-header'
     }
   }, 'made license request with proper licenseHeaders value');
 
@@ -522,7 +522,7 @@ QUnit.test('licenseHeaders and certificateHeaders properties override emeHeaders
     responseType: 'arraybuffer',
     requestType: 'license',
     headers: {
-      'Some-Header': 'higher-priority-cert-header'
+      'some-header': 'higher-priority-cert-header'
     }
   }, 'made certificate request with proper certificateHeaders value');
 

--- a/test/ms-prefixed.test.js
+++ b/test/ms-prefixed.test.js
@@ -275,8 +275,8 @@ QUnit.test('makes request when nothing provided on key message', function(assert
   assert.deepEqual(
     xhrCalls[0].config.headers,
     {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+      'content-type': 'text/xml; charset=utf-8',
+      'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
     },
     'uses headers from message'
   );
@@ -348,8 +348,8 @@ QUnit.test(
     assert.deepEqual(
       xhrCalls[0].config.headers,
       {
-        'Content-Type': 'text/xml; charset=utf-8',
-        'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+        'content-type': 'text/xml; charset=utf-8',
+        'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
       },
       'uses headers from message'
     );
@@ -416,8 +416,8 @@ QUnit.test('makes request with provided url string on key message', function(ass
   assert.deepEqual(
     xhrCalls[0].config.headers,
     {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+      'content-type': 'text/xml; charset=utf-8',
+      'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
     },
     'uses headers from message'
   );
@@ -512,8 +512,8 @@ QUnit.test('makes request with provided url on key message', function(assert) {
   assert.deepEqual(
     xhrCalls[0].config.headers,
     {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
+      'content-type': 'text/xml; charset=utf-8',
+      'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"'
     },
     'uses headers from message'
   );

--- a/test/playready.test.js
+++ b/test/playready.test.js
@@ -66,9 +66,9 @@ QUnit.test('emeHeaders sent with license requests', function(assert) {
     uri: 'some-url',
     method: 'post',
     headers: {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"',
-      'Some-Header': 'some-header-value'
+      'content-type': 'text/xml; charset=utf-8',
+      'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"',
+      'some-header': 'some-header-value'
     },
     body: challengeElement,
     responseType: 'arraybuffer',
@@ -104,9 +104,9 @@ QUnit.test('licenseHeaders property overrides emeHeaders', function(assert) {
     uri: 'some-url',
     method: 'post',
     headers: {
-      'Content-Type': 'text/xml; charset=utf-8',
-      'SOAPAction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"',
-      'Some-Header': 'priority-header-value'
+      'content-type': 'text/xml; charset=utf-8',
+      'soapaction': '"http://schemas.microsoft.com/DRM/2007/03/protocols/AcquireLicense"',
+      'some-header': 'priority-header-value'
     },
     body: challengeElement,
     responseType: 'arraybuffer',


### PR DESCRIPTION
From the README:
```js
player.eme({
  emeHeaders: {

    // Remove the internal default Content-Type
    'Content-Type': null,
    'Custom-Foo': '<CUSTOM_FOO_VALUE>'
  }
});
```
But removing `Content-Type` header is not working this way, because headers are treated case sensitively.

This PR fixes this behavior, by lower casing all headers.