### PR TITLE
fix: type error with legacy fairplay

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -384,7 +384,7 @@ const eme = function(options = {}) {
         // TODO it's possible that the video state must be cleared if reusing the same video
         // element between sources
         setupSessions(player);
-        handleWebKitNeedKeyEvent(event, getOptions(player), player.tech_)
+        handleWebKitNeedKeyEvent(event, getOptions(player), player.tech_, emeError)
           .catch((error) => {
             emeError(error);
           });


### PR DESCRIPTION
## Description
In cases where a fairplay request fails, the following error was occurring: `TypeError: emeError is not a function. (In 'emeError(err, metadata)', 'emeError' is undefined)`. We simply weren't passing in `emeError` to `handleWebKitNeedKeyEvent()` as was expected.