### PR TITLE
fix: check for legacy Fairplay support when switching out of handleEncryptedEvent

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -59,7 +59,7 @@ export function handleEncryptedEvent(player, event, options, sessions, eventBus,
   // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
   // If we are using this keysystem we want to use WebkitMediaKeys.
   // This can be initialized manually with initLegacyFairplay().
-  if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM]) {
+  if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM] && window.WebKitMediaKeys) {
     videojs.log.debug('eme', `Ignoring \'encrypted\' event, using legacy fairplay keySystem ${LEGACY_FAIRPLAY_KEY_SYSTEM}`);
     return Promise.resolve();
   }


### PR DESCRIPTION
If we attempt to play content with both legacy Fairplay and Widevine DRM configured in Chrome, something like this:

```
{
    "com.apple.fps.1_0": {
    ......
    },

    "com.widevine.alpha": {
        "url": "xxxxxxx.xxxxx.xxxx",
    }
},
```
is passed to handleEncryptedEvent, where [this check](https://github.com/videojs/videojs-contrib-eme/blob/8ff427619b00dee2a93aa4dd5472d6814f34b70d/src/plugin.js#L62-L65) detects the presence of the legacy Fairplay configuration, exits out and, as we're in Chrome, playback can't start as Fairplay isn't supported. 

This change adds a simple additional check for `WebKitMediaKeys` for confirmation that the platform supports legacy Fairplay before exiting out of `handleEncryptedEvent`.