### PR TITLE
fix: improve legacy fairplay workflow detection

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -59,7 +59,7 @@ export function handleEncryptedEvent(player, event, options, sessions, eventBus,
   // Legacy fairplay is the keysystem 'com.apple.fps.1_0'.
   // If we are using this keysystem we want to use WebkitMediaKeys.
   // This can be initialized manually with initLegacyFairplay().
-  if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM] && window.WebKitMediaKeys) {
+  if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM] && window.WebKitMediaKeys && player.eme.legacyFairplayIsUsed) {
     videojs.log.debug('eme', `Ignoring \'encrypted\' event, using legacy fairplay keySystem ${LEGACY_FAIRPLAY_KEY_SYSTEM}`);
     return Promise.resolve();
   }
@@ -470,6 +470,7 @@ const eme = function(options = {}) {
         }
       };
 
+      player.eme.legacyFairplayIsUsed = true;
       let videoElement = player.tech_.el_;
 
       // Support Safari EME with FairPlay
@@ -484,6 +485,7 @@ const eme = function(options = {}) {
           videoElement.removeEventListener('webkitneedkey', webkitNeedKeyEventHandler);
         }
 
+        player.eme.legacyFairplayIsUsed = false;
         videoElement = null;
       };
 
@@ -494,6 +496,7 @@ const eme = function(options = {}) {
       return cleanupWebkitNeedKeyHandler;
     },
     detectSupportedCDMs,
+    legacyFairplayIsUsed: false,
     options
   };
 };

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -439,8 +439,11 @@ QUnit.test('handleEncryptedEvent checks for legacy fairplay', function(assert) {
     }
   };
 
+  // this is set by initLegacyFairplay
+  this.player.eme.legacyFairplayIsUsed = true;
+
   handleEncryptedEvent(this.player, this.event1, options, sessions).then(() => {
-    assert.equal(sessions.length, 0, 'did not create a session when no options');
+    assert.equal(sessions.length, 0, 'did not create a session when legacy fairplay is used');
     done();
   });
 });


### PR DESCRIPTION
Following on from #234 I was made aware of a use case where a user's Fairplay key system was provided as `com.apple.fps.1_0` but their custom VJS / contrib-eme setup did not call `initLegacyFairplay`. The were able to get this working by adding `!window.MediaKeys` to my modified exit conditional in `handleEncryptedEvent`.

i.e.:
`if (options.keySystems[LEGACY_FAIRPLAY_KEY_SYSTEM] && window.WebKitMediaKeys && !window.MediaKeys)`

On modern Safari, this will evaluate to false (as both `WebKitMediaKeys` and `MediaKeys` are present), so in their case, `handleEncryptedEvent` would continue with the standard EME workflow.

This got me thinking that we really should be considering whether the legacy Fairplay workflow is actually in use when deciding whether or not to exit `handleEncryptedEvent`, as the key system alone is not definite.

So the changes here make that signal more definite by adding a flag in `initLegacyFairplay` that `handleEncryptedEvent` can use to know for sure that it should exit. 